### PR TITLE
Adds Nix flake build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 
 # clang static-analyzer output
 *.plist
+/result

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ With [Homebrew](https://brew.sh) (macOS or Linux):
 brew install oleksandrchekhovskyi/hax/hax
 ```
 
+With [Nix](https://nixos.org) (flakes enabled):
+
+```sh
+nix run github:OleksandrChekhovskyi/hax -- --help   # fetch, build, and run in one step
+nix profile add github:OleksandrChekhovskyi/hax     # install `hax` into your Nix profile
+```
+
 On Linux, download the prebuilt static binary for your architecture (x86_64 or aarch64) from the
 [latest release](https://github.com/OleksandrChekhovskyi/hax/releases/latest), then unpack the
 `hax` binary into any directory on your `PATH`.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  description = "hax — a minimalist, terminal-native coding agent written in C.";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f {
+        inherit system;
+        pkgs = nixpkgs.legacyPackages.${system};
+      });
+    in {
+      packages = forAllSystems ({ pkgs, ... }: {
+        default = pkgs.stdenv.mkDerivation {
+          pname = "hax";
+          version = "0.3.0";
+          src = self;
+          nativeBuildInputs = with pkgs; [ meson ninja pkg-config ];
+          buildInputs = with pkgs; [ curl jansson ];
+        };
+      });
+
+      devShells = forAllSystems ({ pkgs, ... }: {
+        default = pkgs.mkShell {
+          # Mirrors scripts/install_deps.sh: build/test deps, the optional
+          # runtime tool (fzf, for @file completion), and the lint toolchain
+          # (clang-format, clang-tidy via clang-tools).
+          packages = with pkgs; [
+            # build
+            meson
+            ninja
+            pkg-config
+            curl
+            curl.dev
+            jansson
+            # tests (e2e is Python; interactive UI checks use tmux)
+            python3
+            tmux
+            # optional runtime tool
+            fzf
+            # lint — clang-tools ships nixpkgs-wrapped clang-tidy/clang-format
+            # that can find system headers, but omits the run-clang-tidy
+            # Python driver that scripts/check.sh calls. Pull that one script
+            # from clang-unwrapped; it shells out to the clang-tidy on PATH,
+            # which resolves to the wrapped copy from clang-tools. Pinned to
+            # LLVM 19 (~Debian stable) — the project's .clang-tidy targets
+            # that range, and newer LLVMs surface unrelated new-check noise.
+            llvmPackages_19.clang-tools
+            (writeShellScriptBin "run-clang-tidy"
+              ''exec ${llvmPackages_19.clang-unwrapped}/bin/run-clang-tidy "$@"'')
+          ];
+        };
+      });
+
+      formatter = forAllSystems ({ pkgs, ... }: pkgs.nixfmt);
+    };
+}


### PR DESCRIPTION
This project looks real slick, thank you for releasing it. I wanted to try building it, but I didn't want to use brew on my Nix system, so I build a flake. I documented the one-liner in the README for how you would use it if you merge this, but this is the command I'm using to test it from my own fork:

```
nix run github:EnigmaCurry/hax-agent-fork/nix-flake
```

you can also just clone the repo and run `nix build` to produce `build/hax` as output.

Feel free to close this PR if you feel this is not relevant/useful.