### PR TITLE
Add --json progress events for one-shot mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ notes (see [docs/releasing.md](docs/releasing.md)).
 - `--json` with `-p`: progress events (turn start/end, tool calls, usage) as JSON
   lines on stdout, with the final message as a `result` event; plain-text output is
   replaced, diagnostics stay on stderr.
+- `turn_end` events carry the turn's assistant `text` (omitted when the turn said
+  nothing), so consumers can follow narration as a run unfolds.
 
 ## [0.4.0] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ notes (see [docs/releasing.md](docs/releasing.md)).
 
 ## [Unreleased]
 
+### Added
+
+- `--json` with `-p`: progress events (turn start/end, tool calls, usage) as JSON
+  lines on stdout, with the final message as a `result` event; plain-text output is
+  replaced, diagnostics stay on stderr.
+
 ## [0.4.0] - 2026-08-22
 
 ### Added

--- a/src/agent_core.h
+++ b/src/agent_core.h
@@ -25,6 +25,7 @@ struct hax_opts {
     int raw;                   /* send only user content and advertise no tools */
     const char *resume_path;   /* borrowed session path; NULL starts a new session */
     int provider_autoselected; /* show the one-shot provider-selection banner */
+    int json_events;           /* one-shot: JSONL progress events on stdout instead of text */
 };
 
 const struct tool *agent_find_tool(const char *name);

--- a/src/cli.c
+++ b/src/cli.c
@@ -29,6 +29,9 @@ static const struct help_option {
      "Non-interactive mode. Runs the prompt to completion and prints the final assistant "
      "message to stdout. The prompt comes from PROMPT positional arguments (joined with "
      "spaces) when given, otherwise from stdin if stdin is not a terminal."},
+    {"--json",
+     "With -p: print progress events (turns, tool calls, usage) as JSON lines on stdout instead "
+     "of plain text; the final message arrives as a result event. Diagnostics stay on stderr."},
     {"-c, --continue", "Resume the most recent conversation in this directory."},
     {"--resume[=ID]",
      "Resume a past conversation in this directory. With no ID, pick one from an interactive "
@@ -121,6 +124,7 @@ enum cli_parse_result cli_parse(int argc, char **argv, struct cli_options *optio
         OPT_PRESET,
         OPT_BARE,
         OPT_NO_SESSION,
+        OPT_JSON,
     };
     static const struct option long_options[] = {
         {"help", no_argument, NULL, 'h'},
@@ -131,6 +135,7 @@ enum cli_parse_result cli_parse(int argc, char **argv, struct cli_options *optio
         {"no-session", no_argument, NULL, OPT_NO_SESSION},
         {"raw", no_argument, NULL, OPT_RAW},
         {"bare", no_argument, NULL, OPT_BARE},
+        {"json", no_argument, NULL, OPT_JSON},
         {"provider", required_argument, NULL, OPT_PROVIDER},
         {"model", required_argument, NULL, OPT_MODEL},
         {"effort", required_argument, NULL, OPT_EFFORT},
@@ -185,6 +190,9 @@ enum cli_parse_result cli_parse(int argc, char **argv, struct cli_options *optio
         case OPT_NO_SESSION:
             options->no_session = 1;
             break;
+        case OPT_JSON:
+            options->agent_options.json_events = 1;
+            break;
         case '?':
             fprintf(stderr, "Try 'hax --help' for usage.\n");
             return CLI_PARSE_ERROR;
@@ -209,6 +217,10 @@ enum cli_parse_result cli_parse(int argc, char **argv, struct cli_options *optio
     }
     if (options->one_shot && options->resume_mode == CLI_RESUME_SELECT && !options->resume_id) {
         hax_err("-p with --resume requires a session id (e.g. --resume=ID)");
+        return CLI_PARSE_ERROR;
+    }
+    if (options->agent_options.json_events && !options->one_shot) {
+        hax_err("--json requires -p / --print (interactive mode has no JSON event stream)");
         return CLI_PARSE_ERROR;
     }
     if (!options->one_shot && optind < argc) {

--- a/src/cli.c
+++ b/src/cli.c
@@ -30,8 +30,9 @@ static const struct help_option {
      "message to stdout. The prompt comes from PROMPT positional arguments (joined with "
      "spaces) when given, otherwise from stdin if stdin is not a terminal."},
     {"--json",
-     "With -p: print progress events (turns, tool calls, usage) as JSON lines on stdout instead "
-     "of plain text; the final message arrives as a result event. Diagnostics stay on stderr."},
+     "With -p: print progress events (turns, tool calls, usage, assistant text) as JSON lines "
+     "on stdout instead of plain text; the final message arrives as a result event. Diagnostics "
+     "stay on stderr."},
     {"-c, --continue", "Resume the most recent conversation in this directory."},
     {"--resume[=ID]",
      "Resume a past conversation in this directory. With no ID, pick one from an interactive "

--- a/src/oneshot.c
+++ b/src/oneshot.c
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: MIT */
 #include "oneshot.h"
 
+#include <jansson.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -29,6 +30,7 @@ struct oneshot_state {
     struct spend_totals spend;
     long started_ms;
     long context_tokens;
+    int json_events;
 };
 
 static int account_compaction_event(const struct stream_event *event, void *user)
@@ -64,6 +66,41 @@ static int compact_context(struct oneshot_state *state)
     return completed;
 }
 
+/* Emit one progress event as a JSON line on stdout. Ownership of `event` passes in;
+ * a write failure is silently ignored — progress is advisory, never fatal. */
+static void json_emit(json_t *event)
+{
+    char *line = json_dumps(event, JSON_COMPACT | JSON_ENSURE_ASCII);
+    if (line) {
+        fputs(line, stdout);
+        fputc('\n', stdout);
+        fflush(stdout);
+        free(line);
+    }
+    json_decref(event);
+}
+
+/* Attach usage fields to `object` under "usage"; unknown (-1) counts are omitted. */
+static void json_add_usage(json_t *object, const struct stream_usage *usage)
+{
+    json_t *u = json_object();
+    long total = 0;
+
+    if (usage->input_tokens >= 0) {
+        json_object_set_new(u, "input_tokens", json_integer(usage->input_tokens));
+        total += usage->input_tokens;
+    }
+    if (usage->output_tokens >= 0) {
+        json_object_set_new(u, "output_tokens", json_integer(usage->output_tokens));
+        total += usage->output_tokens;
+    }
+    if (usage->cached_tokens >= 0)
+        json_object_set_new(u, "cached_tokens", json_integer(usage->cached_tokens));
+    if (total > 0)
+        json_object_set_new(u, "totalTokens", json_integer(total));
+    json_object_set_new(object, "usage", u);
+}
+
 static void account_turn(const struct agent_loop_turn *turn, void *user)
 {
     struct oneshot_state *state = user;
@@ -71,6 +108,41 @@ static void account_turn(const struct agent_loop_turn *turn, void *user)
      * charge over their unpriced tokens. */
     agent_spend_account(&state->spend, &turn->usage, state->provider, state->session.model);
     agent_spend_account(&state->spend, &turn->retry_usage, state->provider, state->session.model);
+
+    if (!state->json_events)
+        return;
+    json_t *event = json_object();
+    json_object_set_new(event, "type", json_string("turn_end"));
+    if (turn->served_model)
+        json_object_set_new(event, "model", json_string(turn->served_model));
+    if (turn->elapsed_ms >= 0)
+        json_object_set_new(event, "elapsed_ms", json_integer(turn->elapsed_ms));
+    json_add_usage(event, &turn->usage);
+    json_emit(event);
+}
+
+static void oneshot_turn_begin(void *user)
+{
+    struct oneshot_state *state = user;
+
+    if (!state->json_events)
+        return;
+    json_emit(json_pack("{s:s}", "type", "turn_start"));
+}
+
+static void oneshot_tool_seen(const struct item *call, void *user)
+{
+    struct oneshot_state *state = user;
+
+    if (!state->json_events || !call->tool_name)
+        return;
+    /* Arguments ride as a string, not embedded JSON: a malformed argument blob must
+     * not corrupt the event line. */
+    json_t *event = json_pack("{s:s}", "type", "tool_use");
+    json_object_set_new(event, "name", json_string(call->tool_name));
+    if (call->tool_arguments_json)
+        json_object_set_new(event, "arguments", json_string(call->tool_arguments_json));
+    json_emit(event);
 }
 
 static void auto_compact(void *user)
@@ -167,23 +239,68 @@ static void print_assistant_messages(const struct item *items, size_t from, size
     }
 }
 
+/* Concatenate the final assistant messages the way the text path prints them,
+ * returning an owned string (possibly empty) for the result event. */
+static char *final_messages_text(const struct item *items, size_t from, size_t to)
+{
+    size_t cap = 0;
+
+    for (size_t i = from; i < to; i++) {
+        if (items[i].kind != ITEM_ASSISTANT_MESSAGE || !items[i].text || !*items[i].text)
+            continue;
+        cap += strlen(items[i].text) + 2;
+    }
+    char *text = xmalloc(cap + 1);
+    char *cursor = text;
+
+    for (size_t i = from; i < to; i++) {
+        if (items[i].kind != ITEM_ASSISTANT_MESSAGE || !items[i].text || !*items[i].text)
+            continue;
+        size_t len = strlen(items[i].text);
+        memcpy(cursor, items[i].text, len);
+        cursor += len;
+        if (items[i].text[len - 1] != '\n')
+            *cursor++ = '\n';
+    }
+    *cursor = '\0';
+    return text;
+}
+
 static int handle_loop_result(const struct oneshot_state *state,
                               const struct agent_loop_result *result, int max_turns)
 {
     switch (result->outcome) {
     case AGENT_LOOP_COMPLETE:
-        print_assistant_messages(state->session.items, result->final_items_from,
-                                 result->final_items_to);
+        if (state->json_events) {
+            char *text = final_messages_text(state->session.items, result->final_items_from,
+                                             result->final_items_to);
+            json_emit(json_pack("{s:s,s:s*}", "type", "result", "text", text));
+            free(text);
+        } else {
+            print_assistant_messages(state->session.items, result->final_items_from,
+                                     result->final_items_to);
+        }
         return 0;
     case AGENT_LOOP_PROVIDER_ERROR:
+        if (state->json_events)
+            json_emit(json_pack("{s:s,s:s*}", "type", "error", "message",
+                                result->error_message ? result->error_message : ""));
         hax_err("provider error: %s",
                 result->error_message ? result->error_message : "(no message)");
         return 1;
     case AGENT_LOOP_MAX_TURNS:
+        if (state->json_events) {
+            char *message = xasprintf("max turns (%d) exceeded", max_turns);
+
+            json_emit(json_pack("{s:s,s:s*}", "type", "error", "message", message));
+            free(message);
+        }
         hax_err("max turns (%d) exceeded; aborting", max_turns);
         return 1;
     case AGENT_LOOP_INTERRUPTED:
     case AGENT_LOOP_PAUSED:
+        if (state->json_events)
+            json_emit(json_pack("{s:s}", "type", "interrupted"));
         return 1;
     }
     return 1;
@@ -242,6 +359,7 @@ int oneshot_run(struct provider *provider, const char *prompt, const struct hax_
     struct oneshot_state state = {
         .provider = provider,
         .context_tokens = -1,
+        .json_events = options->json_events,
     };
 
     /* Headless mode still needs fatal signals to terminate its spawned process groups. */
@@ -292,7 +410,9 @@ int oneshot_run(struct provider *provider, const char *prompt, const struct hax_
         .hooks =
             {
                 .user = &state,
+                .turn_begin = oneshot_turn_begin,
                 .turn_end = account_turn,
+                .tool_seen = oneshot_tool_seen,
                 .compact = auto_compact,
             },
     };

--- a/src/oneshot.c
+++ b/src/oneshot.c
@@ -101,6 +101,34 @@ static void json_add_usage(json_t *object, const struct stream_usage *usage)
     json_object_set_new(object, "usage", u);
 }
 
+/* Append one assistant message, padded to end on a newline so consecutive messages
+ * concatenate the way the text path prints them. `message` is non-empty. */
+static void append_message_text(struct buf *text, const char *message)
+{
+    buf_append_str(text, message);
+    if (message[strlen(message) - 1] != '\n')
+        buf_append_str(text, "\n");
+}
+
+/* The turn's assistant text as one owned string: assembled messages plus, on a failed
+ * stream, the unflushed remainder (which repair would keep). Empty when the turn said
+ * nothing. */
+static char *turn_assistant_text(const struct agent_loop_turn *turn)
+{
+    const struct turn *assembly = &turn->assembly;
+    struct buf text = {0};
+
+    for (size_t i = 0; i < assembly->n_items; i++) {
+        const struct item *item = &assembly->items[i];
+        if (item->kind != ITEM_ASSISTANT_MESSAGE || !item->text || !*item->text)
+            continue;
+        append_message_text(&text, item->text);
+    }
+    if (assembly->has_text && assembly->text.data && *assembly->text.data)
+        append_message_text(&text, assembly->text.data);
+    return buf_steal(&text);
+}
+
 static void account_turn(const struct agent_loop_turn *turn, void *user)
 {
     struct oneshot_state *state = user;
@@ -117,6 +145,13 @@ static void account_turn(const struct agent_loop_turn *turn, void *user)
         json_object_set_new(event, "model", json_string(turn->served_model));
     if (turn->elapsed_ms >= 0)
         json_object_set_new(event, "elapsed_ms", json_integer(turn->elapsed_ms));
+    /* Narration rides on turn_end rather than as its own event: a separate
+     * assistant-text event would double-count turns in consumers that count any
+     * assistant message as a turn. */
+    char *text = turn_assistant_text(turn);
+    if (*text)
+        json_object_set_new(event, "text", json_string(text));
+    free(text);
     json_add_usage(event, &turn->usage);
     json_emit(event);
 }
@@ -243,27 +278,14 @@ static void print_assistant_messages(const struct item *items, size_t from, size
  * returning an owned string (possibly empty) for the result event. */
 static char *final_messages_text(const struct item *items, size_t from, size_t to)
 {
-    size_t cap = 0;
+    struct buf text = {0};
 
     for (size_t i = from; i < to; i++) {
         if (items[i].kind != ITEM_ASSISTANT_MESSAGE || !items[i].text || !*items[i].text)
             continue;
-        cap += strlen(items[i].text) + 2;
+        append_message_text(&text, items[i].text);
     }
-    char *text = xmalloc(cap + 1);
-    char *cursor = text;
-
-    for (size_t i = from; i < to; i++) {
-        if (items[i].kind != ITEM_ASSISTANT_MESSAGE || !items[i].text || !*items[i].text)
-            continue;
-        size_t len = strlen(items[i].text);
-        memcpy(cursor, items[i].text, len);
-        cursor += len;
-        if (items[i].text[len - 1] != '\n')
-            *cursor++ = '\n';
-    }
-    *cursor = '\0';
-    return text;
+    return buf_steal(&text);
 }
 
 static int handle_loop_result(const struct oneshot_state *state,

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -51,7 +51,7 @@ def hermetic_env(home: Path) -> dict[str, str]:
     return env
 
 
-def run_oneshot(prompt: str, mock_script: str) -> Result:
+def run_oneshot(prompt: str, mock_script: str, extra_args: list[str] | None = None) -> Result:
     """Run `hax -p <prompt>` against scripts/mock/<mock_script> in a scratch cwd."""
     home = scratch_dir()
     workdir = home / "work"
@@ -63,7 +63,7 @@ def run_oneshot(prompt: str, mock_script: str) -> Result:
     # the caller wrote; decode as UTF-8 regardless of the host locale.
     binary = Path(os.environ.get("HAX_BIN", str(REPO_ROOT / "build" / "hax"))).resolve()
     proc = subprocess.run(
-        [str(binary), "-p", prompt],
+        [str(binary), "-p", prompt, *(extra_args or [])],
         cwd=workdir,
         env=env,
         capture_output=True,

--- a/tests/e2e/test_oneshot_json.py
+++ b/tests/e2e/test_oneshot_json.py
@@ -8,9 +8,19 @@ result = harness.run_oneshot("go", "tool_roundtrip.txt", extra_args=["--json"])
 harness.expect(result.returncode == 0, "exit status is 0", result)
 
 events = []
+turn_ends = []
 for line in result.stdout.splitlines():
     parsed = json.loads(line)  # every stdout line must be valid JSON
     events.append(parsed.get("type"))
+    if parsed.get("type") == "turn_end":
+        turn_ends.append(parsed)
 harness.expect(events == ["turn_start", "turn_end", "tool_use", "turn_start", "turn_end",
                           "result"], f"event sequence is {events}", result)
+
+harness.expect(turn_ends[0].get("text") == "Running a command\n",
+               f"first turn_end carries the narration, got {turn_ends[0].get('text')!r}",
+               result)
+harness.expect(turn_ends[1].get("text") == "Tool finished.\n",
+               f"second turn_end carries the narration, got {turn_ends[1].get('text')!r}",
+               result)
 harness.expect("hax: " not in result.stdout, "no banner text on stdout", result)

--- a/tests/e2e/test_oneshot_json.py
+++ b/tests/e2e/test_oneshot_json.py
@@ -1,0 +1,16 @@
+"""One-shot --json emits JSONL progress events with the result as the last event."""
+
+import json
+
+import harness
+
+result = harness.run_oneshot("go", "tool_roundtrip.txt", extra_args=["--json"])
+harness.expect(result.returncode == 0, "exit status is 0", result)
+
+events = []
+for line in result.stdout.splitlines():
+    parsed = json.loads(line)  # every stdout line must be valid JSON
+    events.append(parsed.get("type"))
+harness.expect(events == ["turn_start", "turn_end", "tool_use", "turn_start", "turn_end",
+                          "result"], f"event sequence is {events}", result)
+harness.expect("hax: " not in result.stdout, "no banner text on stdout", result)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -139,6 +139,7 @@ endforeach
 e2e_scenarios = [
     'oneshot_text',
     'oneshot_tool',
+    'oneshot_json',
 ]
 
 python = find_program('python3')

--- a/tests/test_oneshot.c
+++ b/tests/test_oneshot.c
@@ -150,10 +150,52 @@ static void test_missing_model_is_diagnostic(void)
     captured_run_free(&run);
 }
 
+static struct provider provider_with_stream(struct provider *provider)
+{
+    memset(provider, 0, sizeof(*provider));
+    provider->name = "test-provider";
+    provider->default_model = "unused";
+    provider->stream = response_stream;
+    return *provider;
+}
+
+static void test_json_events_replace_plain_text(void)
+{
+    configure_test_run();
+    struct provider provider;
+
+    provider_with_stream(&provider);
+    fflush(stdout);
+    fflush(stderr);
+    int saved_stdout = dup(STDOUT_FILENO);
+    FILE *out = tmpfile();
+
+    EXPECT(saved_stdout >= 0 && out != NULL);
+    EXPECT(dup2(fileno(out), STDOUT_FILENO) >= 0);
+    struct hax_opts options = {.raw = 1, .json_events = 1};
+    int result = oneshot_run(&provider, "hello", &options, 4);
+    fflush(stdout);
+    EXPECT(dup2(saved_stdout, STDOUT_FILENO) >= 0);
+    close(saved_stdout);
+
+    EXPECT(result == 0);
+    char *text = read_stream(out);
+    fclose(out);
+
+    /* One turn, one result; the plain-text assistant message is absent. */
+    EXPECT(strstr(text, "{\"type\":\"turn_start\"}\n") != NULL);
+    EXPECT(strstr(text, "{\"type\":\"turn_end\"") != NULL);
+    EXPECT(strstr(text, "{\"type\":\"result\"") != NULL);
+    EXPECT(strstr(text, "\"text\":\"first\\nsecond\\n\"") != NULL);
+    EXPECT(strstr(text, "first\nsecond\n\n") == NULL);
+    free(text);
+}
+
 int main(void)
 {
     test_final_messages_are_pipeable();
     test_missing_model_is_diagnostic();
+    test_json_events_replace_plain_text();
     config_free();
     T_REPORT();
 }

--- a/tests/test_oneshot.c
+++ b/tests/test_oneshot.c
@@ -182,11 +182,12 @@ static void test_json_events_replace_plain_text(void)
     char *text = read_stream(out);
     fclose(out);
 
-    /* One turn, one result; the plain-text assistant message is absent. */
+    /* One turn, one result; the plain-text assistant message is absent. The turn's
+     * narration rides on turn_end (text directly before usage), not just result. */
     EXPECT(strstr(text, "{\"type\":\"turn_start\"}\n") != NULL);
     EXPECT(strstr(text, "{\"type\":\"turn_end\"") != NULL);
+    EXPECT(strstr(text, "\"text\":\"first\\nsecond\\n\",\"usage\"") != NULL);
     EXPECT(strstr(text, "{\"type\":\"result\"") != NULL);
-    EXPECT(strstr(text, "\"text\":\"first\\nsecond\\n\"") != NULL);
     EXPECT(strstr(text, "first\nsecond\n\n") == NULL);
     free(text);
 }


### PR DESCRIPTION
Closes #11.

## Why

Headless consumers of `hax -p` (orchestrators, scripts) see only the final plain-text message — no way to observe progress mid-run. codex (`--json`) and claude code (`--output-format=stream-json`) already serve this niche; this gives hax the same composability over pipes.

## What changed

- `--json` (with `-p`; refused otherwise): progress events as JSON lines on **stdout**, final message as a terminal `result` event. Diagnostics (banner, stats, resume hint) stay on **stderr**; plain `-p` output is byte-identical.
- Events: `turn_start`; `turn_end` (served model, elapsed_ms, usage — unknown counts omitted); `tool_use` (name, arguments as a string so a malformed blob cannot corrupt the line); terminal `result` / `error` / `interrupted`.
- Implementation rides the existing agent-loop hooks (`turn_begin`, `turn_end`, `tool_seen`) — no changes to the continuation loop. Emission via jansson (already linked).

~140 lines in `src/oneshot.c` + `src/cli.c`, plus tests, CHANGELOG, README.

## Verification

A reviewer can confirm with the mock provider, no keys needed:

```sh
HAX_PROVIDER=mock HAX_MOCK_SCRIPT=scripts/mock/tool_roundtrip.txt build/hax -p --json go
# → turn_start, turn_end, tool_use, turn_start, turn_end, result (one JSON object per line)
HAX_PROVIDER=mock HAX_MOCK_SCRIPT=scripts/mock/hello.txt build/hax -p hi   # unchanged text mode
build/hax --json   # explicit error: requires -p
```

- `make tests` 104/104; `make lint` clean; ASan build (`BUILD_DIR=build-asan make tests`) 104/104.
- New unit test (`test_oneshot.c`): JSONL replaces plain text, content intact. New hermetic e2e (`test_oneshot_json.py`): exact event sequence, every stdout line parses as JSON, no banner on stdout.
- Manually verified end-to-end against a live model, and as the agent inside my personal orchestration code, where the event stream drove live progress display.

## Models

Implemented with GLM-5.3 (coding agent); independently reviewed by GPT-5 (see review notes on the branch). I have personally inspected the complete changed files and resolved the review findings.