### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,37 @@ jobs:
         if: ${{ matrix.lint }}
         run: make lint
 
+  windows:
+    name: windows
+    runs-on: windows-2025
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Install Meson and Ninja
+        run: python -m pip install meson ninja
+      - name: Build from clean wraps
+        env:
+          CC: clang-cl
+        run: |
+          meson setup build-win
+          meson compile -C build-win
+      - name: Test
+        run: meson test -C build-win --print-errorlogs
+      - name: Verify standalone native imports
+        shell: pwsh
+        run: |
+          $readobj = "$env:ProgramFiles\LLVM\bin\llvm-readobj.exe"
+          $imports = & $readobj --coff-imports build-win\hax.exe | Out-String
+          $imports | Write-Host
+          $forbidden = '(?i)(msys-2\.0|cygwin1|pthread|libcurl|jansson|vcruntime[^.]*|' +
+                       'msvcp[^.]*|ucrtbase|api-ms-win-crt-[^.]+)\.dll'
+          if ($imports -match $forbidden) {
+            throw 'hax.exe imports a forbidden compatibility, dependency, or C runtime DLL'
+          }
+
   # GitHub has no BSD runners, so these boot a QEMU guest on a Linux runner and
   # take longer than the container jobs above. They cannot join that matrix: the
   # whole body has to run inside the VM, which the `cpa.sh` shell arranges.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,57 @@ jobs:
           path: hax-*.tar.gz
           if-no-files-found: error
 
+  windows:
+    name: windows (x86_64)
+    runs-on: windows-2025
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+      - name: Check tag matches project version
+        shell: pwsh
+        run: |
+          $version = "${env:GITHUB_REF_NAME}".TrimStart('v')
+          if (-not (Select-String -Quiet -SimpleMatch "version: '$version'," meson.build)) {
+            throw 'tag does not match project version'
+          }
+      - name: Build and test
+        env:
+          CC: clang-cl
+        run: |
+          python -m pip install meson ninja
+          meson setup build-win --buildtype=release -Dc_args=/Zi -Dc_link_args=/DEBUG:FULL
+          meson compile -C build-win
+          meson test -C build-win --print-errorlogs
+      - name: Verify standalone native imports
+        shell: pwsh
+        run: |
+          $readobj = "$env:ProgramFiles\LLVM\bin\llvm-readobj.exe"
+          $imports = & $readobj --coff-imports build-win\hax.exe | Out-String
+          $imports | Write-Host
+          $forbidden = '(?i)(msys-2\.0|cygwin1|pthread|libcurl|jansson|vcruntime[^.]*|' +
+                       'msvcp[^.]*|ucrtbase|api-ms-win-crt-[^.]+)\.dll'
+          if ($imports -match $forbidden) {
+            throw 'hax.exe imports a forbidden compatibility, dependency, or C runtime DLL'
+          }
+      - name: Package
+        shell: pwsh
+        run: |
+          $version = "${env:GITHUB_REF_NAME}".TrimStart('v')
+          New-Item -ItemType Directory package
+          Copy-Item build-win\hax.exe, build-win\hax.pdb, LICENSE, THIRD_PARTY_NOTICES.md package
+          Compress-Archive package\* "hax-$version-windows-x86_64.zip"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: windows-x86_64
+          path: hax-*.zip
+          if-no-files-found: error
+
   release:
     runs-on: ubuntu-latest
-    needs: static
+    needs: [static, windows]
     timeout-minutes: 30
     steps:
       # Full history so `git describe` (baked into the binary via version.h)
@@ -76,7 +124,7 @@ jobs:
       - name: Collect artifacts and checksums
         run: |
           cp build/meson-dist/*.tar.xz artifacts/
-          (cd artifacts && sha256sum -- *.tar.* > SHA256SUMS)
+          (cd artifacts && sha256sum -- *.tar.* *.zip > SHA256SUMS)
       - name: Extract release notes
         run: scripts/maint/release_notes.py "${GITHUB_REF_NAME#v}" > notes.md
       # Prerelease tags must not become `releases/latest`, which the README's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ notes (see [docs/releasing.md](docs/releasing.md)).
   return to the retry prompt instead of hanging and restore the original console mode on exit.
 - Windows preserves Quick Edit selection and host scrolling while hax is running, and keeps VT
   output enabled across child launches so cursor controls cannot leak around spinner updates.
+- Windows trace and transcript files now open correctly, task output uses race-free positional
+  reads, and console polling preserves navigation and function keys.
+- Windows file opens now enforce no-follow, directory, nonblocking-device, non-inheritance, and
+  private-ACL guarantees instead of silently discarding POSIX flags and modes.
+- Windows Bash commands and background tasks now use opaque process objects with Job Object tree
+  termination and normalized exit states instead of a process-wide pid/wait-status registry.
 
 ## [0.4.0] - 2026-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ notes (see [docs/releasing.md](docs/releasing.md)).
 
 ## [Unreleased]
 
+### Added
+
+- Native x64 Windows support statically links the MSVC C runtime, curl, and Jansson, uses Schannel
+  and Git for Windows Bash, preserves Unix-style paths for model-facing commands and file tools,
+  and ships optional PDB symbols for crash diagnosis.
+
+### Fixed
+
+- Windows no longer terminates when the first prompt materializes a session log.
+
 ## [0.4.0] - 2026-08-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ notes (see [docs/releasing.md](docs/releasing.md)).
 
 ### Fixed
 
-- Windows no longer terminates when the first prompt materializes a session log.
+- Windows no longer terminates when the first prompt materializes a session log. Provider errors
+  return to the retry prompt instead of hanging and restore the original console mode on exit.
+- Windows preserves Quick Edit selection and host scrolling while hax is running, and keeps VT
+  output enabled across child launches so cursor controls cannot leak around spinner updates.
 
 ## [0.4.0] - 2026-08-22
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ like this.
 
 ## Install
 
-hax runs on Linux, macOS, FreeBSD, and OpenBSD; on Windows, use it under
-[WSL](https://learn.microsoft.com/en-us/windows/wsl/). The BSDs build from source only.
+hax runs on Linux, macOS, FreeBSD, OpenBSD, and native x64 Windows 10 or newer. The BSDs
+and Windows currently build from source only.
 
 With [Homebrew](https://brew.sh) (macOS or Linux):
 
@@ -70,6 +70,24 @@ make install              # optional; may prompt for sudo
 `scripts/install_deps.sh` installs the build dependencies — a C compiler, `libcurl`,
 `jansson`, `meson`, `ninja`, and `pkg-config` — plus `fzf`, which hax uses for `@file`
 completion when available. On other platforms, install those packages by hand and run `make`.
+
+On Windows, install Visual Studio 2022 or LLVM with the Windows SDK, Python, Meson, Ninja, and
+[Git for Windows](https://git-scm.com/download/win). From PowerShell:
+
+```powershell
+$env:CC = "clang-cl"  # omit this line to use cl.exe from a VS developer shell
+meson setup build-win
+meson compile -C build-win
+meson test -C build-win --print-errorlogs
+```
+
+Meson downloads the pinned static curl and Jansson wraps during the first setup. The resulting
+`build-win\hax.exe` statically links the MSVC C runtime, curl, and Jansson, and uses Schannel and
+Windows trust, so the executable itself can be copied and run without companion DLLs. Release
+archives also contain an optional `hax.pdb` for debugging; it is not required to run hax. Git for
+Windows supplies the Bash process used for model-generated commands. It can be launched from
+PowerShell, Windows Terminal, or Git Bash.
+Set `HAX_BASH_SHELL` only when automatic Git-for-Windows discovery cannot find the installation.
 
 For hacking on hax, `make symlink` links the freshly built binary into `~/.local/bin` so it
 stays on `PATH` across rebuilds. `make lint` additionally needs `clang-format` and

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,41 @@
+# Third-party notices
+
+The native Windows build statically includes these libraries.
+
+## curl 8.12.1
+
+Copyright (c) 1996 - 2025, Daniel Stenberg, <daniel@haxx.se>, and many contributors.
+
+Permission to use, copy, modify, and distribute this software for any purpose with or without fee
+is hereby granted, provided that the above copyright notice and this permission notice appear in
+all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
+FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall not be used in advertising
+or otherwise to promote the sale, use or other dealings in this Software without prior written
+authorization of the copyright holder.
+
+## Jansson 2.14.1
+
+Copyright (c) 2009-2016 Petri Lehtinen <petri@digip.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/docs/windows-plan.md
+++ b/docs/windows-plan.md
@@ -1,0 +1,607 @@
+# Native Windows support plan
+
+Status: design approved in principle; implementation has not started.
+
+## Objective
+
+Produce a native x64 Windows build of hax that:
+
+- uses the MSVC ABI and does not link to Cygwin, MSYS2, or a pthread compatibility runtime;
+- runs interactively in Windows Terminal and Git Bash/mintty;
+- uses Git for Windows' Bash as the model-facing command shell;
+- preserves hax's Unix-like paths and shell contract instead of exposing Windows details to the
+  model throughout the codebase;
+- builds its pinned libcurl and Jansson sources as part of the Meson build, without vcpkg;
+- retains the existing Linux, macOS, FreeBSD, and OpenBSD behavior and build paths.
+
+Git for Windows itself contains an MSYS2 runtime. That runtime belongs to the separately installed
+`bash.exe` process and its children; it is not loaded into `hax.exe`. The native executable must be
+verifiably free of `msys-2.0.dll`, `cygwin1.dll`, and pthread DLL dependencies.
+
+## Initial support boundary
+
+The first supported target is:
+
+- x86-64 Windows 10 or newer;
+- Clang targeting `x86_64-pc-windows-msvc`, or MSVC from Visual Studio 2022;
+- Windows Terminal, a ConPTY-backed Git Bash/mintty session, or mintty's legacy named-pipe path;
+- Git for Windows installed for command execution;
+- UTF-8 text internally and at the terminal boundary.
+
+The design should not prevent arm64 later, but arm64 is not an initial release gate. Interactive
+startup hard-fails when the terminal cannot provide VT input/output, either through console modes or
+a recognized mintty MSYS pty. Supporting a legacy non-VT Windows console is explicitly out of
+scope.
+
+Running hax from PowerShell must not require Git Bash to be the parent shell. Git Bash is a required
+command backend discovered and launched by native hax. Running hax from Git Bash must also work,
+including when mintty is using a named pipe rather than pcon/ConPTY.
+
+## Architectural rule
+
+Minimize changes to the existing POSIX implementation. Prefer three techniques, in order:
+
+1. compile-time aliases for exact CRT equivalents such as `_stricmp` and `_setmode`;
+2. small Windows compatibility implementations for the subset hax actually uses;
+3. separately selected Windows source files only where process, terminal, or filesystem semantics
+   genuinely differ.
+
+Do not introduce a broad cross-platform framework or rewrite working Unix modules merely to make
+the interfaces theoretically platform-neutral. Provider, conversation, rendering, and tool
+state-machine code should remain unchanged wherever possible. Win32 handles and UTF-16 stay inside
+the small number of Windows implementation files that need them.
+
+The Windows boundary converts UTF-8 to UTF-16 immediately before Win32 APIs and converts results
+back immediately. The rest of hax continues to use UTF-8 and Unix-style paths.
+
+## Dependency strategy
+
+### Meson WrapDB, not vcpkg
+
+Prefer Meson subprojects over vcpkg or a separately installed SDK. WrapDB currently supplies
+`curl` and `jansson` wraps with Meson build definitions, so Windows can build both static libraries
+with the same compiler invocation and CRT settings as hax. CMake is not needed for these
+dependencies.
+
+Pin reviewed WrapDB revisions in `subprojects/*.wrap`. Let Meson download the upstream source and
+WrapDB patch archives on first setup, verifying the hashes recorded by each wrap. Meson's package
+cache can reuse those downloads locally, but the archives do not need to be committed. Do not
+maintain local curl/Jansson source lists or generated configuration headers.
+
+The Windows build therefore requires only:
+
+- a C compiler and Windows SDK;
+- Meson and Ninja;
+- Git for Windows at runtime and while running the Bash-related tests.
+
+Unix builds continue using system `libcurl`, `jansson`, platform threads, and optional `libm`.
+Windows forces the static wrap fallbacks. A developer may still point Meson at compatible native
+static packages for experimentation, but that is not the documented or CI build path.
+
+Dependency license texts must be included in binary release artifacts. CI must exercise a clean
+setup that downloads and hash-verifies every pinned wrap rather than relying on a developer cache.
+
+Both dependencies must use exactly the same MSVC runtime selection as hax. This is load-bearing
+because Jansson allocates strings returned to hax and curl exposes allocation/free pairs across the
+API boundary. Mixed `/MT`, `/MD`, debug, and release CRTs do not reliably fail at link time; they
+can instead produce warnings or cross-heap runtime faults.
+
+### Windows libcurl configuration
+
+The Windows build needs HTTP, HTTPS, proxies, the easy API, URL API, transfer progress, and date
+parsing. It does not need curl's command-line executable, non-HTTP protocols, or HTTP/2/3.
+
+Build static libcurl with:
+
+- Schannel as the only TLS backend and Windows native CA trust;
+- HTTP/1.1 as the only HTTP protocol version;
+- the curl executable, tests, examples, manuals, and documentation disabled;
+- OpenSSL and all other alternate TLS backends disabled;
+- HTTP/2 and HTTP/3 backends disabled explicitly;
+- LDAP, SSH, RTSP, FTP, mail, and other unused protocols disabled;
+- Brotli, zstd, libpsl, libidn2, and external zlib disabled initially.
+
+The exact Meson option names belong to the pinned WrapDB revisions and must be recorded in the
+build. The build must fail if Schannel is silently disabled, if an unexpected third-party library
+is selected, or if curl becomes shared.
+
+HTTPS tests must succeed without a CA bundle or certificate-related environment variable.
+
+### Jansson configuration
+
+Build the WrapDB Jansson subproject as a static library with tests, examples, and documentation
+disabled. Preserve its UTF-8 validation and allocator behavior. Its static-library compile
+definition and CRT selection must propagate through the Meson dependency object.
+
+## Unix-style path façade
+
+### Canonical internal form
+
+Use Git Bash-style paths as hax's canonical internal and model-facing form on Windows:
+
+```text
+C:\Users\alice\src\app  -> /c/Users/alice/src/app
+D:\models                -> /d/models
+\\server\share\repo      -> //server/share/repo
+```
+
+This keeps existing assumptions useful:
+
+- absolute paths begin with `/`;
+- `/` is the only internal separator;
+- `~`, relative paths, and shell quoting retain their existing meaning;
+- commands shown to the model can be pasted into Git Bash;
+- MSYS argument conversion translates `/c/...` for native child programs.
+
+At process startup, normalize command-line paths, the current directory, environment-derived paths,
+and Win32 API results into this form. At filesystem and native process boundaries, translate drive
+and UNC forms back to UTF-16 Windows paths.
+
+Do not scatter drive-letter tests throughout callers. `system/path` owns conversion and root
+semantics.
+
+### Home and application data
+
+Preserve hax's Unix layout consistently regardless of the parent shell:
+
+- use non-empty `HOME` when supplied;
+- otherwise derive home from `%USERPROFILE%` and expose it internally as `/c/Users/...`;
+- continue honoring `XDG_CONFIG_HOME`, `XDG_STATE_HOME`, and `XDG_CACHE_HOME`;
+- retain `~/.config/hax`, `~/.local/state/hax`, and `~/.cache/hax` fallbacks.
+
+Using `%APPDATA%` only when launched from PowerShell would create two independent hax installations
+for the same user, so the initial port deliberately keeps the existing XDG-compatible layout.
+
+Environment paths may arrive as either `C:\...` or `/c/...`; normalize both.
+
+### Git Bash virtual paths
+
+Drive paths and UNC paths are first-class. Git Bash-only virtual roots such as `/usr`, `/mingw64`,
+and custom MSYS mounts cannot always be translated without consulting the MSYS runtime.
+
+The initial file tools guarantee project paths, drive paths, UNC paths, and home-relative paths. If
+a model passes a shell-private absolute path to a native file tool, return a clear error rather than
+adding a `cygpath` subprocess fallback to ordinary path handling.
+
+### Executable lookup
+
+There are two lookup domains:
+
+1. Native programs launched directly use `SearchPathW`, Windows `PATH`, and `PATHEXT`.
+2. Commands intended for the Bash tool are resolved by Git Bash and its transformed POSIX `PATH`.
+
+Do not use the current colon-only `fs_which()` implementation on a native Windows environment.
+Environment discovery shown to the model should describe tools available to Git Bash, because that
+is where model-generated commands run.
+
+## Terminal support
+
+### Terminal classification
+
+Do not use `_isatty()` as the Windows terminal test. Classify each standard handle as one of:
+
+```c
+enum terminal_stream_kind {
+    TERMINAL_STREAM_CONSOLE,
+    TERMINAL_STREAM_MSYS_PTY,
+    TERMINAL_STREAM_REDIRECTED,
+};
+```
+
+Classification order:
+
+1. `GetConsoleMode()` succeeds: a VT-capable console or ConPTY handle, subject to setup succeeding.
+2. The handle is a pipe and its `FileNameInfo` contains a recognized MSYS pty name: mintty's legacy
+   named-pipe path.
+3. Everything else is redirected input/output.
+
+Query pipe names with `GetFileInformationByHandleEx(..., FileNameInfo, ...)`, normalize case, and
+recognize the stable `msys-...-pty...` portion without depending on a full version-specific name.
+Cygwin terminals are not an initial target.
+
+A failed `GetConsoleMode()` means only that console mode calls are unavailable. It must not disable
+ANSI styling or interactivity for a recognized mintty pty. Conversely, interactive startup on an
+unrecognized pipe hard-fails instead of accumulating terminal heuristics.
+
+### Output setup
+
+For a console/ConPTY output handle:
+
+- save the original console mode;
+- require `ENABLE_VIRTUAL_TERMINAL_PROCESSING` and `ENABLE_PROCESSED_OUTPUT` to succeed;
+- save the original output code page and select `CP_UTF8`;
+- restore both later.
+
+If VT mode cannot be enabled, interactive startup exits with one clear unsupported-terminal error.
+There is no legacy Console rendering backend.
+
+Do not enable `DISABLE_NEWLINE_AUTO_RETURN` by default. hax preserves scrollback and emits ordinary
+line-oriented output; the flag is useful for full-screen TUIs but can damage normal newline and
+last-column behavior here.
+
+For a recognized MSYS pty pipe, do not call console mode APIs. Continue emitting VT and OSC
+sequences because mintty parses them at the other end.
+
+Set stdout and stderr to binary mode so the CRT cannot inject CRLF into cursor-addressed output.
+Use unbuffered output for terminal streams, or preserve the existing explicit flush points. A pipe
+that represents mintty must not acquire ordinary fully buffered redirected-output behavior.
+
+For truly redirected output, retain clean one-shot behavior and the existing style policy.
+
+### What startup setup does and does not solve
+
+VT output setup is mostly a one-time operation: after successful classification, the existing ANSI
+renderer can continue writing the same bytes. It does not require a Windows rendering rewrite.
+
+Input still has three small lifecycle requirements after startup:
+
+- switch between raw and cooked modes when hax, an editor, or a picker owns input;
+- wait on a console handle or MSYS pipe without POSIX `poll()`;
+- restore modes on exit and refresh cached size at safe input boundaries.
+
+The legacy mintty pipe also needs an occasional VT size query because no console buffer exists.
+These operations belong in one Windows terminal backend; the editor and escape parsers remain
+shared.
+
+### Input setup
+
+For a console/ConPTY input handle:
+
+- save the original mode and input code page;
+- select `CP_UTF8`;
+- enable `ENABLE_VIRTUAL_TERMINAL_INPUT`;
+- enable `ENABLE_EXTENDED_FLAGS` and clear `ENABLE_QUICK_EDIT_MODE` while hax owns input;
+- switch line input, echo, and processed-input flags according to whether the editor or interrupt
+  watcher currently owns the terminal.
+
+The existing byte-oriented escape parser remains the source of truth for arrows, bracketed paste,
+and editing keys. The backend supplies UTF-8 and VT bytes rather than `INPUT_RECORD` structures.
+
+For a recognized MSYS pty pipe, read bytes directly. Mintty supplies escape sequences without
+console mode changes. Waiting must use Win32 handle/event operations, not CRT `poll()`.
+
+Input ownership remains explicit: the editor, picker, terminal query parser, and interrupt watcher
+must never read concurrently. A small pushback queue preserves bytes that were read while waiting
+for a terminal response but belong to the user.
+
+### Terminal sizing
+
+For console and pcon-backed handles, use `GetConsoleScreenBufferInfo()` and prefer the visible
+window dimensions over the backing buffer dimensions.
+
+For a legacy mintty named pipe:
+
+1. use a recently cached size when available;
+2. while the main input layer exclusively owns stdin, issue `CSI 18 t` and parse the
+   `CSI 8 ; rows ; cols t` response with a short deadline;
+3. retain unrelated input bytes in the pushback queue;
+4. fall back to configured `display_width`, then the existing width default.
+
+Do not use the `ESC[999;999H` cursor-position trick unless `CSI 18 t` proves unusable in supported
+mintty versions; moving the live cursor to discover size is visibly destructive and complicates
+scrollback preservation.
+
+Do not issue terminal queries from rendering or worker threads. Named-pipe dimensions may be
+refreshed at prompt boundaries and other points where the input layer already owns stdin.
+
+### Mode restoration and abnormal exit
+
+Console modes and code pages belong to the shared console, not just hax. Save and restore them:
+
+- during normal mode transitions;
+- in an `atexit` handler;
+- from a `SetConsoleCtrlHandler` handler for Ctrl-C, close, logoff, and shutdown events where the
+  operating system permits cleanup;
+- before launching an editor, pager, picker, or other interactive child.
+
+Cleanup paths must be idempotent. The control handler performs only bounded Win32 operations and
+signals normal code to finish when time permits. Process Job Objects provide the independent
+backstop for child cleanup.
+
+### Required terminal test matrix
+
+Exercise every interactive feature in:
+
+1. Windows Terminal with PowerShell or `cmd.exe`;
+2. Git Bash/mintty with pcon enabled;
+3. Git Bash/mintty with `MSYS=disable_pcon`;
+4. redirected stdin/stdout in one-shot mode.
+
+Checks include Unicode, styling, prompt editing, resize/reflow, bracketed paste, Ctrl-C, Esc/Esc,
+pager/editor transitions, clipboard paste, and restoration after interruption.
+
+## Git Bash discovery
+
+Resolve the command shell once during startup, before background threads begin:
+
+1. if `bash.shell` / `HAX_BASH_SHELL` is set, require that exact executable;
+2. otherwise split native `PATH` on `;` and find the first regular `git.exe`, `git.cmd`, `git.bat`,
+   or `git` entry;
+3. starting at that entry's parent, walk ancestors and test `usr/bin/bash.exe`, then
+   `bin/bash.exe` beneath each ancestor;
+4. require the first match to pass a short `bash -c` identity/path-behavior check.
+
+This deliberately mirrors Git for Windows' layout without registry probes, fixed installation
+paths, WSL-launcher checks, or independent Bash lookup. `git-bash.exe` is not a candidate because it
+opens a terminal window; hax needs the real console shell under `usr/bin` or `bin`.
+
+Cache the normalized Git and Bash paths. If Git, Bash, or validation is missing, print one
+actionable error and exit. Git Bash is part of the Windows runtime contract, not an optional
+capability.
+
+## Process and task backend
+
+### Portable process object
+
+Replace public `pid_t`, POSIX wait status, signal, and raw pipe ownership with an opaque process
+object. The Windows implementation owns:
+
+- process and primary-thread handles;
+- a Job Object;
+- input/output pipe handles;
+- cached exit state and normalized termination reason;
+- shell path and command metadata needed by background tasks.
+
+Callers consume normalized results such as an exit code, interrupted state, timeout state, or
+forced-termination state. POSIX code translates its wait status into the same representation.
+
+### Creation and containment
+
+Launch Git Bash with `CreateProcessW` using:
+
+- an explicitly quoted argv command line;
+- a native UTF-16 working directory;
+- inherited standard handles limited by an explicit handle list;
+- merged stdout/stderr for Bash tool calls;
+- `CREATE_SUSPENDED` so containment exists before user code runs;
+- a Job Object configured with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`.
+
+Assign the suspended process to the job before resuming it. This closes the race in which Bash
+could create an uncontained descendant. Avoid inheritable-handle leaks into unrelated children.
+
+The Git Bash command contract remains `bash -c`, matching Unix. Do not add `-l` or source user
+profiles implicitly; doing so changes command reproducibility and startup side effects.
+
+### Output and waiting
+
+Windows anonymous pipe readiness cannot be treated like POSIX `poll()`. Use either overlapped named
+pipes or a dedicated reader thread plus events. One process abstraction must serve:
+
+- bounded direct-command capture;
+- synchronous streaming Bash calls;
+- background task draining;
+- pager input;
+- fzf output;
+- editor waiting.
+
+Preserve the current output caps, binary detection, spool-file behavior, and live display hooks.
+Never wait for a child while unread output can fill its pipe.
+
+### Cancellation and tree termination
+
+Windows has no reliable general SIGTERM equivalent. Keep the initial backend deterministic:
+`TerminateJobObject()` is the single cancellation operation for timeouts, Esc/Esc, task stops, and
+shutdown. Do not add console-event or `taskkill` fallbacks until a concrete use case justifies their
+extra process-state branches.
+
+The resulting model-facing status describes interruption or forced termination without pretending
+a Unix signal occurred. Existing Unix grace and signal wording remains unchanged on Unix.
+
+The first process prototype must prove that Git Bash commands and their native/MSYS descendants do
+not survive timeout, Esc/Esc, background-task shutdown, or abrupt hax termination. Do this before
+porting the full interactive UI.
+
+## Threads and synchronization
+
+Minimize churn by implementing only the pthread subset hax already uses on Windows: thread
+create/join, mutexes, condition variables, static mutex initialization, timed waits, signal, and
+broadcast. A small internal compatibility header can map those operations to Win32 threads, SRW
+locks, condition variables, and events while leaving the six current pthread-using modules largely
+unchanged. Windows-only signal-mask calls move into the terminal/process backend rather than being
+faked.
+
+PThreads4W is an acceptable fallback if the internal subset proves more complex than expected, but
+it is not the default: vendoring another general-purpose threading package creates more update and
+license work than the small API surface justifies. If selected, it must be statically linked and
+must not add a runtime DLL.
+
+Timed waits and spurious-wakeup behavior need focused tests. Existing Unix code continues to use
+native pthreads unchanged.
+
+## Filesystem and persistence
+
+Implement native UTF-16 filesystem operations for:
+
+- recursive directory creation;
+- regular-file inspection;
+- symlink/reparse-point handling;
+- atomic file replacement;
+- exclusive temporary-file creation;
+- file and directory flushing where Windows provides an equivalent;
+- directory enumeration;
+- session pruning;
+- credential and session locks with `LockFileEx`;
+- executable lookup.
+
+Use `ReplaceFileW` for an existing destination and `MoveFileExW` with appropriate flags for
+creation/fallback. Preserve same-directory staging so replacement remains atomic. Explicitly test
+behavior when antivirus software or another process temporarily holds a file.
+
+Windows ACLs replace POSIX mode bits; do not invent mode emulation. Credential files should inherit
+the user's private profile-directory ACL, and temporary files should be created with non-inheritable
+handles in a private per-process directory.
+
+Session pruning must retain its current race-resistant intent. Windows file identity and sharing
+modes replace inode comparisons and `openat`/`O_NOFOLLOW` checks.
+
+## Other Windows integrations
+
+Implement narrow native backends for:
+
+- clipboard text and image access through Win32 clipboard APIs;
+- keep-awake through `SetThreadExecutionState` or a power request;
+- OS description through Windows version APIs;
+- console notifications through the existing BEL/OSC path where supported;
+- locale initialization without relying on `nl_langinfo()`;
+- command-line parsing without a new getopt dependency;
+- case-insensitive string helpers and the small model-pattern matcher currently using `fnmatch()`.
+
+Retain Schannel's native certificate store. The Unix CA bundle probing code must not run on a
+Schannel build unless an explicit standard curl environment override requires it.
+
+## Source and build organization
+
+Preserve current filenames and Unix implementations unless most of a file is inherently
+platform-specific. Small exact differences may use short `_WIN32` branches. Select a companion
+Windows source only for substantial implementations such as process creation, Bash process
+control, terminal modes/waits, and advanced filesystem operations.
+
+A likely minimal addition set is:
+
+```text
+src/system/win32.c               UTF-8 conversion, paths, errors, handle helpers
+src/system/thread_win32.h        internal pthread subset over Win32 primitives
+src/system/spawn_win32.c         CreateProcess, capture, pipes, and Job Objects
+src/tools/bash_process_win32.c   streaming Bash process ownership
+src/terminal/windows.c           terminal classification, modes, waits, and size
+```
+
+Meson selects these instead of the files whose implementation is wholly POSIX. Pure parsers and
+state machines remain shared. Do not split every existing module into `_posix` and `_win32` pairs as
+an architectural exercise.
+
+## Implementation sequence
+
+### Phase 1: dependency and compile skeleton
+
+- add pinned curl and Jansson WrapDB files;
+- force their static Meson subprojects on Windows with Schannel and HTTP/1.1 only;
+- add Windows source selection and system libraries;
+- establish UTF-8/UTF-16 and basic error helpers;
+- compile a native `hax.exe` far enough to enumerate remaining unsupported modules;
+- verify its import table has no MSYS/Cygwin/pthread runtime.
+
+Exit gate: a clean Windows setup downloads the pinned wraps and links a minimal native executable
+with static Jansson and Schannel curl; curl reports Schannel and no unexpected dependency backend.
+
+### Phase 2: Unix path façade and basic filesystem
+
+- normalize argv, environment, cwd, home, drive, and UNC paths;
+- port file reading, writing, directory creation, temporary files, and config lookup;
+- add a portable command-line parser and string compatibility helpers;
+- run pure unit tests and one-shot raw/mock flows without invoking a shell command.
+
+Exit gate: `hax.exe --version`, `--help`, raw one-shot mode, config loading, sessions, and native
+read/edit/write work in a Unicode path.
+
+### Phase 3: Git Bash process prototype
+
+- implement discovery and validation;
+- implement CreateProcess, pipes, normalized exit status, and Job Objects;
+- run ordinary, Unicode-path, timeout, descendant, and forced-shutdown commands;
+- prove no descendant survives containment cleanup in all supported launch terminals.
+
+Exit gate: synchronous Bash calls and process-tree termination pass focused tests in PowerShell and
+Git Bash.
+
+### Phase 4: full tools and background tasks
+
+- port streaming display, output spooling, background task adoption, waits, and shutdown;
+- port direct git capture, fzf pipes, editor, and pager execution;
+- keep Git Bash discovery as one mandatory startup check rather than per-feature branches.
+
+Exit gate: Bash and task suites pass with equivalent output/timeout semantics, adjusted only where
+Windows has no signal identity.
+
+### Phase 5: terminal backends
+
+- add console/ConPTY mode management;
+- add MSYS pty pipe recognition;
+- port input waiting and interruption;
+- add terminal size query/caching for the legacy mintty pipe path;
+- add mode restoration and binary/unbuffered stream setup.
+
+Exit gate: the complete interactive test matrix works and every exit path restores its parent
+terminal.
+
+### Phase 6: native integrations and hardening
+
+- clipboard, keep-awake, OS description, and Schannel-specific CA tests;
+- race, handle-leak, cancellation, and Unicode audits;
+- package a standalone `hax.exe` plus notices;
+- document installation and Git for Windows detection;
+- add Windows CI and release artifacts.
+
+Exit gate: automated Windows tests, manual terminal scenarios, Unix tests, release build, and lint
+all pass.
+
+## Verification
+
+### Automated gates
+
+Windows CI must run:
+
+```text
+meson setup build-win
+meson compile -C build-win
+meson test -C build-win --print-errorlogs
+```
+
+It must additionally:
+
+- configure from an empty Meson package cache and verify wrap hashes;
+- inspect `hax.exe` imports for forbidden runtimes;
+- verify libcurl reports Schannel;
+- exercise HTTPS against a controlled test endpoint/certificate setup;
+- run Python one-shot end-to-end scenarios;
+- test Unicode paths, spaces, drive roots, and UNC fixtures where CI permits them;
+- prove timeout and shutdown kill a nested Bash descendant tree;
+- verify missing or invalid Git Bash produces one startup error and a nonzero exit.
+
+Existing Unix CI remains mandatory. Windows abstractions must not weaken POSIX process cleanup,
+credential locking, or terminal behavior.
+
+### Manual gates
+
+Run the interactive checklist in Windows Terminal, mintty pcon, and mintty with
+`MSYS=disable_pcon`. Capture:
+
+- detected terminal kind and dimensions in a debug-only diagnostic;
+- prompt and streamed Markdown rendering;
+- Unicode and emoji alignment;
+- editing keys and bracketed paste;
+- Ctrl-C, Esc, Esc/Esc, close-window, and abnormal tool termination;
+- pager/editor/fzf return to the original prompt;
+- foreground and background descendant cleanup;
+- terminal mode restoration after every case.
+
+## Early proof points and stop conditions
+
+Resolve these before broad mechanical porting:
+
+1. The pinned WrapDB builds must propagate static curl/Jansson targets, one CRT selection, and
+   Windows system link requirements correctly.
+2. A Job Object must contain Git Bash's process behavior under both pcon and legacy mintty paths.
+3. The MSYS named-pipe heuristic must distinguish a terminal from ordinary redirected pipes.
+4. `CSI 18 t` must provide reliable sizing on the supported legacy mintty path without losing user
+   input.
+5. Console control handling and byte input must preserve current Ctrl-C and Esc semantics.
+
+If any proof point has no defensible implementation, stop that phase with the failing prototype,
+observed handles/process tree, attempted approaches, and the smallest decision needed next. Do not
+hide a failed containment or terminal assumption behind reduced tests.
+
+## Completion criteria
+
+Native Windows support is complete when:
+
+- a clean machine with the documented compiler, Meson, Ninja, Git for Windows, and network access
+  can download the pinned wraps and build the repository;
+- the resulting `hax.exe` has no Cygwin, MSYS2, pthread, curl, or Jansson DLL dependency;
+- HTTPS uses Schannel and Windows trust without OpenSSL or a bundled CA file;
+- model-facing paths and commands remain consistently Unix-like;
+- PowerShell, Windows Terminal, mintty pcon, and mintty legacy-pipe scenarios behave transparently;
+- missing or invalid Git Bash fails startup once with a clear diagnostic and nonzero status;
+- process descendants, terminal modes, handles, credentials, sessions, and temporary files retain
+  their cleanup and safety guarantees;
+- all Windows and existing Unix verification gates pass.

--- a/docs/windows-plan.md
+++ b/docs/windows-plan.md
@@ -1,6 +1,7 @@
 # Native Windows support plan
 
-Status: design approved in principle; implementation has not started.
+Status: initial native x64 implementation landed; legacy mintty sizing and the manual terminal
+matrix remain release gates.
 
 ## Objective
 

--- a/meson.build
+++ b/meson.build
@@ -5,8 +5,11 @@ project('hax', 'c',
         'c_std=c11',
         'warning_level=3',
         'buildtype=debugoptimized',
+        'b_vscrt=mt',
     ],
 )
+
+is_windows = host_machine.system() == 'windows'
 
 # glibc hides POSIX 2008 interfaces until asked for them, while the BSD libcs
 # expose POSIX by default and read these macros as a request to *hide* their
@@ -23,29 +26,118 @@ if host_machine.system() == 'linux'
     )
 endif
 
-add_project_arguments(
-    '-D_DARWIN_C_SOURCE',
-    # Project headers go through -iquote, not -I, so `#include <foo.h>`
-    # always reaches a system header rather than shadowing it with one
-    # of ours (e.g. `src/util.h` would collide with macOS's `<util.h>`
-    # under -I). The `tests/` entry serves the same purpose for
-    # `harness.h` and friends.
-    '-iquote', meson.project_source_root() / 'src',
-    '-iquote', meson.project_source_root() / 'tests',
-    language: 'c',
-)
+if is_windows
+    add_project_arguments(
+        '/utf-8',
+        '/D_CRT_SECURE_NO_WARNINGS',
+        language: 'c',
+    )
+    win32_includes = include_directories('src/system/win32_include', 'src', 'tests')
+    win32_compile_args = ['/FIhax_win32.h']
+else
+    add_project_arguments(
+        '-D_DARWIN_C_SOURCE',
+        # Project headers go through -iquote, not -I, so `#include <foo.h>`
+        # always reaches a system header rather than shadowing it with one
+        # of ours (e.g. `src/util.h` would collide with macOS's `<util.h>`
+        # under -I). The `tests/` entry serves the same purpose for
+        # `harness.h` and friends.
+        '-iquote', meson.project_source_root() / 'src',
+        '-iquote', meson.project_source_root() / 'tests',
+        language: 'c',
+    )
+    win32_includes = include_directories()
+    win32_compile_args = []
+endif
 
-# include_type system turns the dependencies' -I flags into -isystem so
-# clang-tidy does not report findings inside third-party headers (Homebrew
-# installs them outside the default system include path).
-libcurl = dependency('libcurl', include_type: 'system')
-jansson = dependency('jansson', include_type: 'system')
-threads = dependency('threads')
+# Windows always builds reviewed static wraps with Schannel. Keeping the options here makes an
+# upstream default change fail closed rather than silently adding a TLS or protocol dependency.
+if is_windows
+    curl_project = subproject('curl', default_options: [
+        'default_library=static',
+        'b_vscrt=mt',
+        'tool=disabled',
+        'tests=disabled',
+        'unittests=disabled',
+        'ssl=enabled',
+        'schannel=enabled',
+        'ssl-default-backend=schannel',
+        'openssl=disabled',
+        'secure-transport=disabled',
+        'http2=disabled',
+        'alt-svc=disabled',
+        'brotli=disabled',
+        'cookies=disabled',
+        'doh=disabled',
+        'form-api=disabled',
+        'gsasl=disabled',
+        'hsts=disabled',
+        'netrc=disabled',
+        'socketpair=disabled',
+        'unixsockets=disabled',
+        'websockets=disabled',
+        'zstd=disabled',
+        'psl=disabled',
+        'idn=disabled',
+        'libz=disabled',
+        'asynchdns-resolver=win32',
+        'aws=disabled',
+        'digest-auth=disabled',
+        'kerberos-auth=disabled',
+        'negotiate-auth=disabled',
+        'ntlm=disabled',
+        'dict=disabled',
+        'file=disabled',
+        'ftp=disabled',
+        'gopher=disabled',
+        'imap=disabled',
+        'ipfs=disabled',
+        'ldap=disabled',
+        'ldaps=disabled',
+        'mqtt=disabled',
+        'pop3=disabled',
+        'rtmp=disabled',
+        'rtsp=disabled',
+        'smb=disabled',
+        'smtp=disabled',
+        'telnet=disabled',
+        'tftp=disabled',
+        'ssh=disabled',
+    ])
+    libcurl = curl_project.get_variable('curl_dep')
+    jansson_project = subproject(
+        'jansson',
+        default_options: ['default_library=static', 'b_vscrt=mt'],
+    )
+    jansson = jansson_project.get_variable('jansson_dep')
+    threads = declare_dependency()
+else
+    # include_type system turns the dependencies' -I flags into -isystem so clang-tidy does not
+    # report findings inside third-party headers installed outside the compiler's system path.
+    libcurl = dependency('libcurl', include_type: 'system')
+    jansson = dependency('jansson', include_type: 'system')
+    threads = dependency('threads')
+endif
 
 # FreeBSD resolves isfinite() to a libm symbol rather than a compiler builtin,
 # so the math library has to be linked explicitly there. Optional because
 # platforms that fold the math functions into libc ship no separate library.
 libm = meson.get_compiler('c').find_library('m', required: false)
+if is_windows
+    win32_system = declare_dependency(
+        dependencies: [
+            meson.get_compiler('c').find_library('advapi32'),
+            meson.get_compiler('c').find_library('bcrypt'),
+            meson.get_compiler('c').find_library('ole32'),
+            meson.get_compiler('c').find_library('shell32'),
+            meson.get_compiler('c').find_library('user32'),
+        ],
+        compile_args: win32_compile_args,
+        include_directories: win32_includes,
+    )
+else
+    win32_system = declare_dependency()
+endif
 
 fs = import('fs')
 
@@ -103,7 +195,6 @@ sources = files(
     'src/select.c',
     'src/session.c',
     'src/session_picker.c',
-    'src/session_prune.c',
     'src/slash.c',
     'src/tool_schema.c',
     'src/trace.c',
@@ -154,10 +245,9 @@ sources = files(
     'src/system/keepawake.c',
     'src/system/os.c',
     'src/system/path.c',
-    'src/system/spawn.c',
     'src/system/tempfiles.c',
+    'src/system/win32.c',
 
-    'src/terminal/clipboard.c',
     'src/terminal/input.c',
     'src/terminal/input_core.c',
     'src/terminal/interrupt.c',
@@ -198,6 +288,21 @@ sources = files(
     'src/transport/sse.c',
 )
 
+if is_windows
+    sources += files(
+        'src/session_prune_win32.c',
+        'src/system/spawn_win32.c',
+        'src/terminal/clipboard_win32.c',
+        'src/terminal/windows.c',
+    )
+else
+    sources += files(
+        'src/session_prune.c',
+        'src/system/spawn.c',
+        'src/terminal/clipboard.c',
+    )
+endif
+
 # One archive shared by the executable and every test. Static-archive linking
 # is lazy: each consumer pulls only the objects it transitively references, so
 # tests get exactly the closure they need without hand-listing sources. The
@@ -206,7 +311,7 @@ sources = files(
 hax_lib = static_library('hax_lib',
     sources,
     version_h,
-    dependencies: [libcurl, jansson, threads, libm],
+    dependencies: [libcurl, jansson, threads, libm, win32_system],
 )
 
 # Wrap the library as a dependency so consumers inherit both the link against
@@ -223,6 +328,7 @@ hax_dep = declare_dependency(
         libcurl.partial_dependency(compile_args: true, includes: true),
         jansson.partial_dependency(compile_args: true, includes: true),
         threads.partial_dependency(compile_args: true, includes: true),
+        win32_system.partial_dependency(compile_args: true, includes: true),
     ],
 )
 
@@ -231,5 +337,13 @@ hax_exe = executable('hax',
     dependencies: [hax_dep],
     install: true,
 )
+
+if is_windows
+    install_data(
+        'LICENSE',
+        'THIRD_PARTY_NOTICES.md',
+        install_dir: get_option('datadir') / 'hax',
+    )
+endif
 
 subdir('tests')

--- a/meson.build
+++ b/meson.build
@@ -30,6 +30,7 @@ if is_windows
     add_project_arguments(
         '/utf-8',
         '/D_CRT_SECURE_NO_WARNINGS',
+        '/D_WIN32_WINNT=0x0a00',
         language: 'c',
     )
     win32_includes = include_directories('src/system/win32_include', 'src', 'tests')

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,7 @@
 #include "transcript.h"
 #include "util.h"
 #include "providers/registry.h"
+#include "system/spawn.h"
 #include "terminal/theme.h"
 #include "transport/ca.h"
 
@@ -166,6 +167,9 @@ static void initialize_run_services(const char *resume_path)
 
 int main(int argc, char **argv)
 {
+#ifdef _WIN32
+    win32_process_init(&argc, &argv);
+#endif
     initialize_config();
 
     int result = 1;
@@ -181,6 +185,16 @@ int main(int argc, char **argv)
     }
     if (parse_result == CLI_PARSE_ERROR || cli_check_subagent_depth() != 0)
         goto cleanup_config;
+#ifdef _WIN32
+    const char *configured_bash = config_str("bash.shell");
+    if (configured_bash && *configured_bash)
+        setenv("HAX_BASH_SHELL", configured_bash, 1);
+    if (!spawn_win32_bash_available()) {
+        hax_err("Git for Windows Bash was not found or failed validation; install Git for Windows "
+                "or set HAX_BASH_SHELL");
+        goto cleanup_config;
+    }
+#endif
     if (cli_read_prompt(&options, argc, argv, stdin, isatty(fileno(stdin)), &prompt) != 0)
         goto cleanup_config;
 

--- a/src/main.c
+++ b/src/main.c
@@ -251,5 +251,8 @@ cleanup_config:
     config_free();
     free(prompt);
     free(resume_path);
+#ifdef _WIN32
+    win32_terminal_release();
+#endif
     return result;
 }

--- a/src/session.c
+++ b/src/session.c
@@ -27,7 +27,9 @@
 /* struct stat's sub-second mtime field is spelled differently across
  * platforms. Used to break ties between sessions created in the same
  * second so --continue / the picker reliably pick the most recent. */
-#if defined(__APPLE__)
+#if defined(_WIN32)
+#define ST_MTIME_NSEC(st) 0L
+#elif defined(__APPLE__)
 #define ST_MTIME_NSEC(st) ((long)(st).st_mtimespec.tv_nsec)
 #else
 #define ST_MTIME_NSEC(st) ((long)(st).st_mtim.tv_nsec)
@@ -558,7 +560,12 @@ static FILE *open_session_file(const char *path, enum session_file_mode mode)
     FILE *file = fdopen(fd, mode == SESSION_FILE_APPEND ? "a" : "w");
     if (!file)
         goto error;
+#ifdef _WIN32
+    /* UCRT rejects size-zero line buffering and does not implement line-buffered mode. */
+    setvbuf(file, NULL, _IONBF, 0);
+#else
     setvbuf(file, NULL, _IOLBF, 0);
+#endif
     return file;
 
 error:

--- a/src/session_prune_win32.c
+++ b/src/session_prune_win32.c
@@ -1,0 +1,198 @@
+/* SPDX-License-Identifier: MIT */
+#ifdef _WIN32
+
+#include <dirent.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+#include <sys/file.h>
+#include <sys/stat.h>
+
+#include "config.h"
+#include "session.h"
+#include "session_prune.h"
+#include "util.h"
+#include "system/bg_job.h"
+#include "system/path.h"
+
+#define SESSION_PRUNE_INTERVAL_S (24 * 60 * 60)
+
+struct prune_args {
+    char *sessions_dir;
+    char *exclude_path;
+    char *marker_path;
+    time_t cutoff;
+    int marker_fd;
+};
+
+static struct bg_job *active_prune_job;
+
+time_t session_retention_cutoff(void)
+{
+    int days = config_int("session_retention_days");
+    if (days <= 0)
+        return 0;
+    return time(NULL) - (time_t)days * 24 * 60 * 60;
+}
+
+static int prune_tree(const char *sessions_dir, time_t cutoff, const char *exclude_path,
+                      struct bg_job *job)
+{
+    DIR *sessions = opendir(sessions_dir);
+    if (!sessions)
+        return 0;
+
+    for (struct dirent *project_entry; (project_entry = readdir(sessions));) {
+        if (bg_job_cancel_requested(job)) {
+            closedir(sessions);
+            return -1;
+        }
+        if (project_entry->d_name[0] == '.')
+            continue;
+
+        char *project_path = path_join(sessions_dir, project_entry->d_name);
+        struct stat project_stat;
+        if (project_entry->d_type == DT_LNK || stat(project_path, &project_stat) != 0 ||
+            !S_ISDIR(project_stat.st_mode)) {
+            free(project_path);
+            continue;
+        }
+        DIR *project = opendir(project_path);
+        if (!project) {
+            free(project_path);
+            continue;
+        }
+
+        for (struct dirent *session_entry; (session_entry = readdir(project));) {
+            if (bg_job_cancel_requested(job)) {
+                closedir(project);
+                free(project_path);
+                closedir(sessions);
+                return -1;
+            }
+            if (!session_path_is_standard(session_entry->d_name) || session_entry->d_type == DT_LNK)
+                continue;
+
+            char *session_path = path_join(project_path, session_entry->d_name);
+            struct stat observed;
+            if (stat(session_path, &observed) != 0 || !S_ISREG(observed.st_mode) ||
+                observed.st_mtime >= cutoff ||
+                (exclude_path && strcmp(session_path, exclude_path) == 0)) {
+                free(session_path);
+                continue;
+            }
+
+            int fd = open(session_path, O_RDONLY | O_CLOEXEC | O_NOFOLLOW);
+            struct stat locked;
+            if (fd >= 0 && flock(fd, LOCK_EX | LOCK_NB) == 0 && fstat(fd, &locked) == 0 &&
+                S_ISREG(locked.st_mode) && locked.st_mtime < cutoff &&
+                locked.st_size == observed.st_size)
+                (void)unlink(session_path);
+            if (fd >= 0)
+                close(fd);
+            free(session_path);
+        }
+        closedir(project);
+        (void)rmdir(project_path);
+        free(project_path);
+    }
+    closedir(sessions);
+    return 0;
+}
+
+int session_prune_before(time_t cutoff, const char *exclude_path)
+{
+    char *sessions_dir = xdg_hax_state_path("sessions");
+    if (!sessions_dir)
+        return 0;
+    int result = prune_tree(sessions_dir, cutoff, exclude_path, NULL);
+    free(sessions_dir);
+    return result;
+}
+
+static void prune_args_free(struct prune_args *args)
+{
+    if (!args)
+        return;
+    free(args->sessions_dir);
+    free(args->exclude_path);
+    free(args->marker_path);
+    free(args);
+}
+
+static void prune_worker(struct bg_job *job, void *opaque)
+{
+    struct prune_args *args = opaque;
+    if (prune_tree(args->sessions_dir, args->cutoff, args->exclude_path, job) == 0) {
+        (void)ftruncate(args->marker_fd, 0);
+        (void)lseek(args->marker_fd, 0, SEEK_SET);
+        (void)write_all(args->marker_fd, "1", 1);
+    }
+    (void)flock(args->marker_fd, LOCK_UN);
+    close(args->marker_fd);
+    prune_args_free(args);
+}
+
+void session_prune_start(const char *exclude_path)
+{
+    if (active_prune_job)
+        return;
+    time_t cutoff = session_retention_cutoff();
+    if (!cutoff)
+        return;
+
+    char *sessions_dir = xdg_hax_state_path("sessions");
+    struct stat sessions_stat;
+    if (!sessions_dir || stat(sessions_dir, &sessions_stat) != 0 ||
+        !S_ISDIR(sessions_stat.st_mode)) {
+        free(sessions_dir);
+        return;
+    }
+
+    char *marker_path = path_join(sessions_dir, ".prune");
+    int marker_fd = open(marker_path, O_CREAT | O_RDWR | O_CLOEXEC, 0600);
+    if (marker_fd < 0 || flock(marker_fd, LOCK_EX | LOCK_NB) != 0) {
+        if (marker_fd >= 0)
+            close(marker_fd);
+        free(marker_path);
+        free(sessions_dir);
+        return;
+    }
+
+    struct stat marker_stat;
+    time_t now = time(NULL);
+    if (fstat(marker_fd, &marker_stat) == 0 && marker_stat.st_size > 0 &&
+        (now <= marker_stat.st_mtime || now - marker_stat.st_mtime < SESSION_PRUNE_INTERVAL_S)) {
+        (void)flock(marker_fd, LOCK_UN);
+        close(marker_fd);
+        free(marker_path);
+        free(sessions_dir);
+        return;
+    }
+
+    struct prune_args *args = xcalloc(1, sizeof(*args));
+    args->sessions_dir = sessions_dir;
+    args->exclude_path = exclude_path ? xstrdup(exclude_path) : NULL;
+    args->marker_path = marker_path;
+    args->cutoff = cutoff;
+    args->marker_fd = marker_fd;
+    active_prune_job = bg_job_spawn(prune_worker, args);
+    if (!active_prune_job) {
+        (void)flock(marker_fd, LOCK_UN);
+        close(marker_fd);
+        prune_args_free(args);
+    }
+}
+
+void session_prune_shutdown(void)
+{
+    if (!active_prune_job)
+        return;
+    bg_job_cancel(active_prune_job);
+    bg_job_join(active_prune_job);
+    active_prune_job = NULL;
+}
+
+#endif /* _WIN32 */

--- a/src/slash.c
+++ b/src/slash.c
@@ -616,6 +616,8 @@ static void run_tasks(const struct command_call *call)
         char elapsed_label[16];
         if (tasks[i].running)
             snprintf(state_label, sizeof(state_label), "running");
+        else if (tasks[i].forced)
+            snprintf(state_label, sizeof(state_label), "forced");
         else if (tasks[i].term_signal)
             snprintf(state_label, sizeof(state_label), "signal %d", tasks[i].term_signal);
         else

--- a/src/system/fs.c
+++ b/src/system/fs.c
@@ -303,9 +303,12 @@ char *fs_which(const char *name)
 {
     if (!name || !*name)
         return NULL;
-    if (strchr(name, '/'))
+    if (strchr(name, '/') || strchr(name, '\\'))
         return is_executable_file(name) ? xstrdup(name) : NULL;
 
+#ifdef _WIN32
+    return hax_search_path(name);
+#else
     const char *path_env = getenv("PATH");
     if (!path_env)
         return NULL;
@@ -328,6 +331,7 @@ char *fs_which(const char *name)
             return NULL;
         entry = separator + 1;
     }
+#endif
 }
 
 char *fs_shell_head(const char *shell_cmd)

--- a/src/system/fs.c
+++ b/src/system/fs.c
@@ -164,9 +164,13 @@ static int inspect_write_target(const char *path, struct write_target *target, c
         return -1;
     }
 
+#ifdef _WIN32
+    target->mode = 0666;
+#else
     mode_t mask = umask(0);
     umask(mask);
     target->mode = 0666 & ~mask;
+#endif
     return 0;
 }
 
@@ -208,11 +212,16 @@ static char *stage_write(const char *parent, const char *content, size_t content
         goto error;
     }
 
-    /* write(2) may clear set-ID bits, so restore the destination mode afterward. */
+#ifndef _WIN32
+    /* write(2) may clear set-ID bits, so restore the destination mode afterward. Windows
+     * replacement files inherit ACLs instead of emulating POSIX mode bits. */
     if (fchmod(fd, mode) < 0) {
         *error = xasprintf("chmod %s: %s", temp_path, strerror(errno));
         goto error;
     }
+#else
+    (void)mode;
+#endif
     /* Surface delayed-allocation failures before replacing the destination. */
     if (fsync(fd) < 0) {
         *error = xasprintf("fsync %s: %s", temp_path, strerror(errno));

--- a/src/system/keepawake.c
+++ b/src/system/keepawake.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #endif
 
+#ifndef _WIN32
 /* Calls occur on the main thread at the user-turn boundary. */
 static pid_t helper_pid;
 
@@ -21,6 +22,7 @@ static void reap_dead_helper(void)
     if (helper_pid > 0 && spawn_reap_if_exited(helper_pid))
         helper_pid = 0;
 }
+#endif
 
 #if defined(__APPLE__) || defined(__linux__)
 static const char *resolve_executable(const char *const *candidates)
@@ -50,9 +52,9 @@ static int systemd_inhibit_supports_no_ask_password(const char *path)
 }
 #endif
 
+#if defined(__APPLE__) || defined(__linux__)
 static void spawn_helper(void)
 {
-#if defined(__APPLE__) || defined(__linux__)
     pid_t parent_pid = getpid();
     /* Resolve before fork; PATH lookup may allocate and deadlock after a multithreaded fork. */
 #ifdef __APPLE__
@@ -100,8 +102,8 @@ static void spawn_helper(void)
         _exit(127);
     }
     helper_pid = pid;
-#endif
 }
+#endif
 
 void keepawake_acquire(void)
 {

--- a/src/system/keepawake.c
+++ b/src/system/keepawake.c
@@ -107,14 +107,21 @@ void keepawake_acquire(void)
 {
     if (!config_bool_or("keep_awake", 1))
         return;
+#ifdef _WIN32
+    SetThreadExecutionState(ES_CONTINUOUS | ES_SYSTEM_REQUIRED);
+#else
     reap_dead_helper();
     if (helper_pid > 0)
         return;
     spawn_helper();
+#endif
 }
 
 void keepawake_release(void)
 {
+#ifdef _WIN32
+    SetThreadExecutionState(ES_CONTINUOUS);
+#else
     if (helper_pid <= 0)
         return;
     kill(helper_pid, SIGTERM);
@@ -122,4 +129,5 @@ void keepawake_release(void)
      * macOS) must not hang the turn boundary; escalate instead of waiting forever. */
     (void)spawn_wait_child_timeout(helper_pid, 500);
     helper_pid = 0;
+#endif
 }

--- a/src/system/path.c
+++ b/src/system/path.c
@@ -112,3 +112,44 @@ char *path_relativize(const char *path, const char *cwd)
         relative++;
     return *relative ? xstrdup(relative) : NULL;
 }
+
+static int ascii_drive_letter(char value)
+{
+    return (value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z');
+}
+
+char *path_normalize_windows(const char *path)
+{
+    if (!path)
+        return NULL;
+
+    const char *source = path;
+    int extended_unc = strncmp(source, "\\\\?\\UNC\\", 8) == 0;
+    if (extended_unc)
+        source += 8;
+    else if (strncmp(source, "\\\\?\\", 4) == 0)
+        source += 4;
+
+    struct buf normalized;
+    buf_init(&normalized);
+    if (extended_unc)
+        buf_append_str(&normalized, "//");
+    if (ascii_drive_letter(source[0]) && source[1] == ':' &&
+        (source[2] == '\0' || source[2] == '/' || source[2] == '\\')) {
+        char drive = source[0] >= 'A' && source[0] <= 'Z' ? source[0] - 'A' + 'a' : source[0];
+        buf_append_str(&normalized, "/");
+        buf_append(&normalized, &drive, 1);
+        source += 2;
+        if (*source && *source != '/' && *source != '\\')
+            buf_append_str(&normalized, "/");
+    } else if (!extended_unc && source[0] == '\\' && source[1] == '\\') {
+        buf_append_str(&normalized, "//");
+        source += 2;
+    }
+
+    for (; *source; source++) {
+        char value = *source == '\\' ? '/' : *source;
+        buf_append(&normalized, &value, 1);
+    }
+    return buf_steal(&normalized);
+}

--- a/src/system/path.h
+++ b/src/system/path.h
@@ -21,4 +21,8 @@ char *path_collapse_home(const char *path);
  * unrelated paths, equality, and paths containing a `..` component. */
 char *path_relativize(const char *path, const char *cwd);
 
+/* Normalize a Windows drive, UNC, or separator spelling to the canonical Git Bash-style UTF-8
+ * form. Relative paths remain relative. This is a lexical transform and accepts canonical input. */
+char *path_normalize_windows(const char *path);
+
 #endif /* HAX_SYSTEM_PATH_H */

--- a/src/system/spawn.c
+++ b/src/system/spawn.c
@@ -109,6 +109,106 @@ void spawn_child_die_with_parent(pid_t parent_pid, int signal_number)
 #endif
 }
 
+struct spawn_process {
+    pid_t pid;
+};
+
+static void exec_bash_child(const char *shell, const char *argv0, const char *command,
+                            char *const envp[])
+{
+    close(STDIN_FILENO);
+    (void)open("/dev/null", O_RDONLY);
+    char *const argv[] = {(char *)argv0, (char *)"-c", (char *)command, NULL};
+    execve(shell, argv, envp);
+    _exit(127);
+}
+
+struct spawn_process *spawn_process_start_bash(const char *shell, const char *argv0,
+                                               const char *command, char *const envp[],
+                                               int *output_fd)
+{
+    if (!shell || !argv0 || !command || !output_fd) {
+        errno = EINVAL;
+        return NULL;
+    }
+    int pipe_fds[2];
+    if (pipe(pipe_fds) < 0)
+        return NULL;
+
+    pid_t parent_pid = getpid();
+    pid_t pid = fork();
+    if (pid < 0) {
+        int saved_errno = errno;
+        close(pipe_fds[0]);
+        close(pipe_fds[1]);
+        errno = saved_errno;
+        return NULL;
+    }
+    if (pid == 0) {
+        close(pipe_fds[0]);
+        setsid();
+        spawn_child_die_with_parent(parent_pid, SIGKILL);
+        dup2(pipe_fds[1], STDOUT_FILENO);
+        dup2(pipe_fds[1], STDERR_FILENO);
+        if (pipe_fds[1] > STDERR_FILENO)
+            close(pipe_fds[1]);
+        exec_bash_child(shell, argv0, command, envp);
+    }
+
+    close(pipe_fds[1]);
+    struct spawn_process *process = xmalloc(sizeof(*process));
+    process->pid = pid;
+    *output_fd = pipe_fds[0];
+    return process;
+}
+
+void spawn_process_terminate(struct spawn_process *process, int signal_number)
+{
+    if (!process)
+        return;
+    if (kill(-process->pid, signal_number) < 0 && errno == ESRCH)
+        kill(process->pid, signal_number);
+}
+
+int spawn_process_exit_seen(struct spawn_process *process, int *exit_seen)
+{
+    if (!process || !exit_seen) {
+        errno = EINVAL;
+        return -1;
+    }
+    siginfo_t info = {0};
+    int result = waitid(P_PID, (id_t)process->pid, &info, WEXITED | WNOHANG | WNOWAIT);
+    if (result == 0 && info.si_pid == process->pid)
+        *exit_seen = 1;
+    return result;
+}
+
+int spawn_process_wait(struct spawn_process *process, struct spawn_status *status)
+{
+    if (!process || !status) {
+        errno = EINVAL;
+        return -1;
+    }
+    int wait_status;
+    while (waitpid(process->pid, &wait_status, 0) < 0) {
+        if (errno != EINTR) {
+            int saved_errno = errno;
+            free(process);
+            errno = saved_errno;
+            return -1;
+        }
+    }
+    if (WIFEXITED(wait_status)) {
+        *status = (struct spawn_status){.end = SPAWN_END_EXITED, .code = WEXITSTATUS(wait_status)};
+    } else if (WIFSIGNALED(wait_status)) {
+        *status = (struct spawn_status){.end = SPAWN_END_SIGNALED, .code = WTERMSIG(wait_status)};
+    } else {
+        *status = (struct spawn_status){.end = SPAWN_END_FORCED};
+    }
+    free(process);
+    return 0;
+}
+
 int spawn_wait_child(pid_t pid)
 {
     int status;

--- a/src/system/spawn.h
+++ b/src/system/spawn.h
@@ -5,11 +5,13 @@
 #include <signal.h>
 #include <stdio.h>
 
+#ifndef _WIN32
 struct spawn_signal_state {
     struct sigaction sigint;
     struct sigaction sigquit;
     struct sigaction sigpipe;
 };
+#endif
 
 /* Run `shell_cmd` via /bin/sh and return its waitpid status, or -1 on error. */
 int spawn_shell_wait(const char *shell_cmd);
@@ -28,47 +30,58 @@ char *spawn_shell_cmd_force_utf8(char *shell_cmd);
 char *spawn_capture_stdout(const char *const *argv, size_t max_bytes, int timeout_ms,
                            size_t *out_len);
 
+#ifndef _WIN32
 /* Ignore terminal signals in the parent while a child runs. The child must reset them before
  * exec, and the parent must restore `state` after waiting. This follows system() semantics for
  * SIGINT and SIGQUIT; SIGPIPE also protects parent writes to a child that exits early. */
 void spawn_parent_ignore_signals(struct spawn_signal_state *state);
 void spawn_parent_restore_signals(const struct spawn_signal_state *state);
 void spawn_child_reset_signals(void);
-
-/* Redirect all three standard descriptors to /dev/null on a best-effort basis. */
 void spawn_child_redirect_stdio_to_null(void);
-
-/* On Linux, arrange for the post-fork child to receive `signal_number` when `parent_pid` dies.
- * `parent_pid` must be captured before fork so the helper can close the fork/arm race. This is a
- * no-op where PR_SET_PDEATHSIG is unavailable. */
 void spawn_child_die_with_parent(pid_t parent_pid, int signal_number);
 
-/* Return the child's waitpid status, retrying EINTR, or -1 on error. */
+/* POSIX-only helpers for platform integrations that fork directly. */
 int spawn_wait_child(pid_t pid);
-
-/* spawn_wait_child with a deadline: a child still running after timeout_ms is SIGKILLed and
- * reaped. For children that normally exit promptly but must never hang the caller. */
 int spawn_wait_child_timeout(pid_t pid, int timeout_ms);
-
-/* Reap an exited child and return 1; return 0 if it is running or waitpid otherwise fails.
- * ECHILD counts as exited. */
 int spawn_reap_if_exited(pid_t pid);
+#endif
+
+struct spawn_process;
+
+enum spawn_end {
+    SPAWN_END_EXITED,
+    SPAWN_END_SIGNALED,
+    SPAWN_END_FORCED,
+};
+
+struct spawn_status {
+    enum spawn_end end;
+    int code; /* exit code for EXITED, signal number for SIGNALED, otherwise zero */
+};
+
+/* Start an isolated Bash process with merged output. `shell` and `argv0` are required on POSIX and
+ * ignored on Windows, where the validated Git Bash installation is used. The returned opaque
+ * process owns the process tree until spawn_process_wait consumes it. */
+struct spawn_process *spawn_process_start_bash(const char *shell, const char *argv0,
+                                               const char *command, char *const envp[],
+                                               int *output_fd);
+void spawn_process_terminate(struct spawn_process *process, int signal_number);
+int spawn_process_exit_seen(struct spawn_process *process, int *exit_seen);
+int spawn_process_wait(struct spawn_process *process, struct spawn_status *status);
 
 #ifdef _WIN32
-/* Windows Bash backend: the returned process is job-contained and remains registered until
- * spawn_win32_waitpid reaps it. */
 int spawn_win32_bash_available(void);
 char *spawn_win32_bash_path(void);
-int spawn_win32_start_bash(const char *command, char *const envp[], pid_t *pid, int *output_fd);
-void spawn_win32_terminate(pid_t pid);
-int spawn_win32_exit_seen(pid_t pid, int *exit_seen);
-pid_t spawn_win32_waitpid(pid_t pid, int *status, int options);
 #endif
 
 struct spawn_pipe {
     FILE *stream;
+#ifdef _WIN32
+    struct spawn_process *process;
+#else
     pid_t pid;
     struct spawn_signal_state parent_signals;
+#endif
 };
 
 /* Open a pipe to a shell command. The write variant connects `stream` to the child's stdin; the

--- a/src/system/spawn.h
+++ b/src/system/spawn.h
@@ -54,6 +54,17 @@ int spawn_wait_child_timeout(pid_t pid, int timeout_ms);
  * ECHILD counts as exited. */
 int spawn_reap_if_exited(pid_t pid);
 
+#ifdef _WIN32
+/* Windows Bash backend: the returned process is job-contained and remains registered until
+ * spawn_win32_waitpid reaps it. */
+int spawn_win32_bash_available(void);
+char *spawn_win32_bash_path(void);
+int spawn_win32_start_bash(const char *command, char *const envp[], pid_t *pid, int *output_fd);
+void spawn_win32_terminate(pid_t pid);
+int spawn_win32_exit_seen(pid_t pid, int *exit_seen);
+pid_t spawn_win32_waitpid(pid_t pid, int *status, int options);
+#endif
+
 struct spawn_pipe {
     FILE *stream;
     pid_t pid;

--- a/src/system/spawn_win32.c
+++ b/src/system/spawn_win32.c
@@ -1,0 +1,727 @@
+/* SPDX-License-Identifier: MIT */
+#ifdef _WIN32
+
+#include <errno.h>
+#include <fcntl.h>
+#include <io.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <windows.h>
+#include <sys/wait.h>
+
+#include "util.h"
+#include "system/path.h"
+#include "system/spawn.h"
+
+struct child_record {
+    pid_t pid;
+    HANDLE process;
+    HANDLE job;
+    struct child_record *next;
+};
+
+static SRWLOCK child_lock = SRWLOCK_INIT;
+static struct child_record *children;
+
+static wchar_t *utf8_to_wide(const char *text)
+{
+    int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text, -1, NULL, 0);
+    if (length <= 0)
+        return NULL;
+    wchar_t *wide = xmalloc((size_t)length * sizeof(*wide));
+    if (!MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text, -1, wide, length)) {
+        free(wide);
+        return NULL;
+    }
+    return wide;
+}
+
+static wchar_t *internal_path_to_wide(const char *path)
+{
+    if (!path)
+        return NULL;
+    char *native;
+    if (path[0] == '/' && path[1] && path[2] == '/') {
+        native = xasprintf("%c:%s", path[1] >= 'a' ? path[1] - 'a' + 'A' : path[1], path + 2);
+    } else if (path[0] == '/' && path[1] == '/') {
+        native = xasprintf("\\\\%s", path + 2);
+    } else {
+        native = xstrdup(path);
+    }
+    for (char *cursor = native; *cursor; cursor++)
+        if (*cursor == '/')
+            *cursor = '\\';
+    wchar_t *wide = utf8_to_wide(native);
+    free(native);
+    return wide;
+}
+
+static void append_quoted_arg(struct buf *command, const char *argument)
+{
+    int quote = !*argument || strpbrk(argument, " \t\n\v\"") != NULL;
+    if (!quote) {
+        buf_append_str(command, argument);
+        return;
+    }
+    buf_append_str(command, "\"");
+    size_t backslashes = 0;
+    for (const char *cursor = argument;; cursor++) {
+        if (*cursor == '\\') {
+            backslashes++;
+            continue;
+        }
+        if (*cursor == '\"' || *cursor == '\0') {
+            for (size_t i = 0; i < backslashes * 2 + (*cursor == '\"'); i++)
+                buf_append_str(command, "\\");
+        } else {
+            for (size_t i = 0; i < backslashes; i++)
+                buf_append_str(command, "\\");
+        }
+        backslashes = 0;
+        if (*cursor == '\0')
+            break;
+        buf_append(command, cursor, 1);
+    }
+    buf_append_str(command, "\"");
+}
+
+static wchar_t *argv_command_line(const char *const *argv)
+{
+    struct buf command;
+    buf_init(&command);
+    for (size_t i = 0; argv[i]; i++) {
+        if (i)
+            buf_append_str(&command, " ");
+        append_quoted_arg(&command, argv[i]);
+    }
+    char *utf8 = buf_steal(&command);
+    wchar_t *wide = utf8_to_wide(utf8);
+    free(utf8);
+    return wide;
+}
+
+static wchar_t *search_executable(const char *name)
+{
+    wchar_t *wide_name = internal_path_to_wide(name);
+    if (!wide_name)
+        return NULL;
+    if (wcschr(wide_name, L'\\') || wcschr(wide_name, L'/')) {
+        DWORD attributes = GetFileAttributesW(wide_name);
+        if (attributes != INVALID_FILE_ATTRIBUTES && !(attributes & FILE_ATTRIBUTE_DIRECTORY))
+            return wide_name;
+        free(wide_name);
+        return NULL;
+    }
+    DWORD length = SearchPathW(NULL, wide_name, NULL, 0, NULL, NULL);
+    if (!length) {
+        free(wide_name);
+        return NULL;
+    }
+    wchar_t *path = xmalloc(((size_t)length + 1) * sizeof(*path));
+    if (!SearchPathW(NULL, wide_name, NULL, length + 1, path, NULL)) {
+        free(path);
+        path = NULL;
+    }
+    free(wide_name);
+    return path;
+}
+
+static int regular_file(const wchar_t *path)
+{
+    DWORD attributes = GetFileAttributesW(path);
+    return attributes != INVALID_FILE_ATTRIBUTES && !(attributes & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+static wchar_t *find_git_bash(void)
+{
+    const char *configured = getenv("HAX_BASH_SHELL");
+    if (configured && *configured)
+        return search_executable(configured);
+
+    static const char *const GIT_CANDIDATES[] = {"git.exe", "git.cmd", "git.bat", "git"};
+    wchar_t *git = NULL;
+    for (size_t i = 0; !git && i < sizeof(GIT_CANDIDATES) / sizeof(*GIT_CANDIDATES); i++)
+        git = search_executable(GIT_CANDIDATES[i]);
+    if (!git)
+        return NULL;
+    wchar_t *slash = wcsrchr(git, L'\\');
+    if (slash)
+        *slash = L'\0';
+
+    for (;;) {
+        static const wchar_t *const BASH_LOCATIONS[] = {L"usr\\bin\\bash.exe", L"bin\\bash.exe"};
+        for (size_t i = 0; i < sizeof(BASH_LOCATIONS) / sizeof(*BASH_LOCATIONS); i++) {
+            size_t length = wcslen(git) + 1 + wcslen(BASH_LOCATIONS[i]) + 1;
+            wchar_t *candidate = xmalloc(length * sizeof(*candidate));
+            _snwprintf(candidate, length, L"%ls\\%ls", git, BASH_LOCATIONS[i]);
+            if (regular_file(candidate)) {
+                free(git);
+                return candidate;
+            }
+            free(candidate);
+        }
+        slash = wcsrchr(git, L'\\');
+        if (!slash || slash == git + 2)
+            break;
+        *slash = L'\0';
+    }
+    free(git);
+    return NULL;
+}
+
+struct child_start {
+    PROCESS_INFORMATION process_info;
+    HANDLE job;
+};
+
+static int start_process(const wchar_t *application, wchar_t *command_line, HANDLE stdin_handle,
+                         HANDLE stdout_handle, HANDLE stderr_handle, void *environment,
+                         struct child_start *out)
+{
+    STARTUPINFOEXW startup = {0};
+    startup.StartupInfo.cb = sizeof(startup);
+    startup.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    startup.StartupInfo.hStdInput = stdin_handle;
+    startup.StartupInfo.hStdOutput = stdout_handle;
+    startup.StartupInfo.hStdError = stderr_handle;
+
+    HANDLE inherited[3];
+    size_t inherited_count = 0;
+    const HANDLE candidates[] = {stdin_handle, stdout_handle, stderr_handle};
+    for (size_t i = 0; i < sizeof(candidates) / sizeof(*candidates); i++) {
+        int duplicate = 0;
+        for (size_t j = 0; j < inherited_count; j++)
+            duplicate |= inherited[j] == candidates[i];
+        if (!duplicate && candidates[i] && candidates[i] != INVALID_HANDLE_VALUE)
+            inherited[inherited_count++] = candidates[i];
+    }
+    SIZE_T attributes_size = 0;
+    InitializeProcThreadAttributeList(NULL, 1, 0, &attributes_size);
+    startup.lpAttributeList = xmalloc(attributes_size);
+    if (!InitializeProcThreadAttributeList(startup.lpAttributeList, 1, 0, &attributes_size) ||
+        !UpdateProcThreadAttribute(startup.lpAttributeList, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+                                   inherited, inherited_count * sizeof(*inherited), NULL, NULL)) {
+        free(startup.lpAttributeList);
+        return -1;
+    }
+    HANDLE job = CreateJobObjectW(NULL, NULL);
+    if (!job) {
+        DeleteProcThreadAttributeList(startup.lpAttributeList);
+        free(startup.lpAttributeList);
+        return -1;
+    }
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits = {0};
+    limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    if (!SetInformationJobObject(job, JobObjectExtendedLimitInformation, &limits, sizeof(limits))) {
+        CloseHandle(job);
+        DeleteProcThreadAttributeList(startup.lpAttributeList);
+        free(startup.lpAttributeList);
+        return -1;
+    }
+
+    PROCESS_INFORMATION process_info;
+    win32_terminal_release();
+    BOOL created =
+        CreateProcessW(application, command_line, NULL, NULL, TRUE,
+                       CREATE_SUSPENDED | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT,
+                       environment, NULL, &startup.StartupInfo, &process_info);
+    win32_terminal_acquire();
+    DeleteProcThreadAttributeList(startup.lpAttributeList);
+    free(startup.lpAttributeList);
+    if (!created) {
+        CloseHandle(job);
+        return -1;
+    }
+    if (!AssignProcessToJobObject(job, process_info.hProcess)) {
+        TerminateProcess(process_info.hProcess, 1);
+        CloseHandle(process_info.hThread);
+        CloseHandle(process_info.hProcess);
+        CloseHandle(job);
+        return -1;
+    }
+    ResumeThread(process_info.hThread);
+    CloseHandle(process_info.hThread);
+    *out = (struct child_start){.process_info = process_info, .job = job};
+    return 0;
+}
+
+static int child_finish(struct child_start *child, DWORD timeout_ms, int terminate_on_timeout)
+{
+    DWORD wait = WaitForSingleObject(child->process_info.hProcess, timeout_ms);
+    if (wait == WAIT_TIMEOUT && terminate_on_timeout) {
+        TerminateJobObject(child->job, 1);
+        wait = WaitForSingleObject(child->process_info.hProcess, INFINITE);
+    }
+    DWORD exit_code = 1;
+    if (wait == WAIT_OBJECT_0)
+        GetExitCodeProcess(child->process_info.hProcess, &exit_code);
+    CloseHandle(child->process_info.hProcess);
+    CloseHandle(child->job);
+    return wait == WAIT_OBJECT_0 ? (int)(exit_code & 0xff) : -1;
+}
+
+static void child_publish(struct child_start *child)
+{
+    struct child_record *record = xmalloc(sizeof(*record));
+    record->pid = (pid_t)child->process_info.dwProcessId;
+    record->process = child->process_info.hProcess;
+    record->job = child->job;
+    AcquireSRWLockExclusive(&child_lock);
+    record->next = children;
+    children = record;
+    ReleaseSRWLockExclusive(&child_lock);
+}
+
+static struct child_record *child_take(pid_t pid)
+{
+    AcquireSRWLockExclusive(&child_lock);
+    struct child_record **link = &children;
+    while (*link && (*link)->pid != pid)
+        link = &(*link)->next;
+    struct child_record *record = *link;
+    if (record)
+        *link = record->next;
+    ReleaseSRWLockExclusive(&child_lock);
+    return record;
+}
+
+static int compare_env(const void *left, const void *right)
+{
+    const char *const *a = left;
+    const char *const *b = right;
+    return _stricmp(*a, *b);
+}
+
+static wchar_t *environment_block(char *const envp[])
+{
+    size_t count = 0;
+    while (envp && envp[count])
+        count++;
+    if (!count)
+        return NULL;
+    qsort((void *)envp, count, sizeof(*envp), compare_env);
+
+    size_t capacity = 1024;
+    size_t length = 0;
+    wchar_t *block = xmalloc(capacity * sizeof(*block));
+    for (size_t i = 0; i < count; i++) {
+        int item_length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, envp[i], -1, NULL, 0);
+        if (item_length <= 0) {
+            free(block);
+            return NULL;
+        }
+        if (length + (size_t)item_length + 1 > capacity) {
+            while (length + (size_t)item_length + 1 > capacity)
+                capacity *= 2;
+            block = xrealloc(block, capacity * sizeof(*block));
+        }
+        MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, envp[i], -1, block + length,
+                            item_length);
+        length += (size_t)item_length;
+    }
+    block[length] = L'\0';
+    return block;
+}
+
+static wchar_t *bash_command_line(const wchar_t *bash, const char *shell_cmd)
+{
+    char *bash_utf8 = NULL;
+    int length = WideCharToMultiByte(CP_UTF8, 0, bash, -1, NULL, 0, NULL, NULL);
+    if (length > 0) {
+        bash_utf8 = xmalloc((size_t)length);
+        WideCharToMultiByte(CP_UTF8, 0, bash, -1, bash_utf8, length, NULL, NULL);
+    }
+    if (!bash_utf8)
+        return NULL;
+    const char *argv[] = {bash_utf8, "--noprofile", "--norc", "-c", shell_cmd, NULL};
+    wchar_t *command_line = argv_command_line(argv);
+    free(bash_utf8);
+    return command_line;
+}
+
+char *spawn_win32_bash_path(void)
+{
+    wchar_t *bash = find_git_bash();
+    if (!bash)
+        return NULL;
+    int length = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, bash, -1, NULL, 0, NULL, NULL);
+    char *native = length > 0 ? xmalloc((size_t)length) : NULL;
+    if (native)
+        WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, bash, -1, native, length, NULL, NULL);
+    free(bash);
+    if (!native)
+        return NULL;
+    char *canonical = path_normalize_windows(native);
+    free(native);
+    return canonical;
+}
+
+int spawn_win32_bash_available(void)
+{
+    wchar_t *bash = find_git_bash();
+    if (!bash)
+        return 0;
+    wchar_t *command_line = bash_command_line(
+        bash, "test -n \"$BASH_VERSION\" && cd /c && test \"$(pwd -W)\" = C:/");
+    struct child_start child;
+    int started = command_line ? start_process(bash, command_line, GetStdHandle(STD_INPUT_HANDLE),
+                                               GetStdHandle(STD_OUTPUT_HANDLE),
+                                               GetStdHandle(STD_ERROR_HANDLE), NULL, &child)
+                               : -1;
+    free(command_line);
+    free(bash);
+    return started == 0 && child_finish(&child, 3000, 1) == 0;
+}
+
+int spawn_win32_start_bash(const char *command, char *const envp[], pid_t *pid, int *output_fd)
+{
+    SECURITY_ATTRIBUTES security = {.nLength = sizeof(security), .bInheritHandle = TRUE};
+    HANDLE read_handle;
+    HANDLE write_handle;
+    if (!CreatePipe(&read_handle, &write_handle, &security, 0))
+        return -1;
+    SetHandleInformation(read_handle, HANDLE_FLAG_INHERIT, 0);
+    HANDLE null_handle =
+        CreateFileW(L"NUL", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    &security, OPEN_EXISTING, 0, NULL);
+    wchar_t *bash = find_git_bash();
+    wchar_t *command_line = bash ? bash_command_line(bash, command) : NULL;
+    wchar_t *environment = environment_block(envp);
+    struct child_start child;
+    int started = bash && command_line && environment
+                      ? start_process(bash, command_line, null_handle, write_handle, write_handle,
+                                      environment, &child)
+                      : -1;
+    free(environment);
+    free(command_line);
+    free(bash);
+    CloseHandle(write_handle);
+    CloseHandle(null_handle);
+    if (started != 0) {
+        CloseHandle(read_handle);
+        errno = ENOENT;
+        return -1;
+    }
+
+    int fd = _open_osfhandle((intptr_t)read_handle, _O_RDONLY | _O_BINARY);
+    if (fd < 0) {
+        CloseHandle(read_handle);
+        TerminateJobObject(child.job, 1);
+        (void)child_finish(&child, INFINITE, 0);
+        return -1;
+    }
+    child_publish(&child);
+    *pid = (pid_t)child.process_info.dwProcessId;
+    *output_fd = fd;
+    return 0;
+}
+
+void spawn_win32_terminate(pid_t pid)
+{
+    AcquireSRWLockShared(&child_lock);
+    struct child_record *record = children;
+    while (record && record->pid != pid)
+        record = record->next;
+    if (record)
+        TerminateJobObject(record->job, 1);
+    ReleaseSRWLockShared(&child_lock);
+}
+
+int spawn_win32_exit_seen(pid_t pid, int *exit_seen)
+{
+    AcquireSRWLockShared(&child_lock);
+    struct child_record *record = children;
+    while (record && record->pid != pid)
+        record = record->next;
+    if (!record) {
+        ReleaseSRWLockShared(&child_lock);
+        errno = ECHILD;
+        return -1;
+    }
+    if (WaitForSingleObject(record->process, 0) == WAIT_OBJECT_0)
+        *exit_seen = 1;
+    ReleaseSRWLockShared(&child_lock);
+    return 0;
+}
+
+pid_t spawn_win32_waitpid(pid_t pid, int *status, int options)
+{
+    AcquireSRWLockShared(&child_lock);
+    struct child_record *found = children;
+    while (found && found->pid != pid)
+        found = found->next;
+    if (!found) {
+        ReleaseSRWLockShared(&child_lock);
+        errno = ECHILD;
+        return -1;
+    }
+    DWORD wait = WaitForSingleObject(found->process, options & WNOHANG ? 0 : INFINITE);
+    ReleaseSRWLockShared(&child_lock);
+    if (wait == WAIT_TIMEOUT)
+        return 0;
+    if (wait != WAIT_OBJECT_0)
+        return -1;
+
+    struct child_record *record = child_take(pid);
+    if (!record) {
+        errno = ECHILD;
+        return -1;
+    }
+    DWORD exit_code = 1;
+    GetExitCodeProcess(record->process, &exit_code);
+    if (status)
+        *status = (int)(exit_code & 0xff);
+    CloseHandle(record->process);
+    CloseHandle(record->job);
+    free(record);
+    return pid;
+}
+
+char *spawn_shell_cmd_force_utf8(char *shell_cmd)
+{
+    return shell_cmd;
+}
+
+void spawn_parent_ignore_signals(struct spawn_signal_state *state)
+{
+    memset(state, 0, sizeof(*state));
+}
+
+void spawn_parent_restore_signals(const struct spawn_signal_state *state)
+{
+    (void)state;
+}
+
+void spawn_child_reset_signals(void)
+{
+}
+
+void spawn_child_redirect_stdio_to_null(void)
+{
+}
+
+void spawn_child_die_with_parent(pid_t parent_pid, int signal_number)
+{
+    (void)parent_pid;
+    (void)signal_number;
+}
+
+int spawn_shell_wait(const char *shell_cmd)
+{
+    wchar_t *bash = find_git_bash();
+    wchar_t *command_line = bash ? bash_command_line(bash, shell_cmd) : NULL;
+    if (!bash || !command_line) {
+        free(bash);
+        free(command_line);
+        errno = ENOENT;
+        return -1;
+    }
+    struct child_start child;
+    int result = start_process(bash, command_line, GetStdHandle(STD_INPUT_HANDLE),
+                               GetStdHandle(STD_OUTPUT_HANDLE), GetStdHandle(STD_ERROR_HANDLE),
+                               NULL, &child);
+    free(command_line);
+    free(bash);
+    return result == 0 ? child_finish(&child, INFINITE, 0) : -1;
+}
+
+enum spawn_pipe_mode {
+    SPAWN_PIPE_READ,
+    SPAWN_PIPE_WRITE,
+};
+
+static int pipe_open(struct spawn_pipe *result, const char *shell_cmd, enum spawn_pipe_mode mode)
+{
+    memset(result, 0, sizeof(*result));
+    SECURITY_ATTRIBUTES security = {.nLength = sizeof(security), .bInheritHandle = TRUE};
+    HANDLE read_handle;
+    HANDLE write_handle;
+    if (!CreatePipe(&read_handle, &write_handle, &security, 0))
+        return -1;
+    HANDLE parent_handle = mode == SPAWN_PIPE_READ ? read_handle : write_handle;
+    HANDLE child_handle = mode == SPAWN_PIPE_READ ? write_handle : read_handle;
+    SetHandleInformation(parent_handle, HANDLE_FLAG_INHERIT, 0);
+
+    wchar_t *bash = find_git_bash();
+    wchar_t *command_line = bash ? bash_command_line(bash, shell_cmd) : NULL;
+    struct child_start child;
+    int started =
+        bash && command_line
+            ? start_process(
+                  bash, command_line,
+                  mode == SPAWN_PIPE_WRITE ? child_handle : GetStdHandle(STD_INPUT_HANDLE),
+                  mode == SPAWN_PIPE_READ ? child_handle : GetStdHandle(STD_OUTPUT_HANDLE),
+                  GetStdHandle(STD_ERROR_HANDLE), NULL, &child)
+            : -1;
+    free(command_line);
+    free(bash);
+    CloseHandle(child_handle);
+    if (started != 0) {
+        CloseHandle(parent_handle);
+        errno = ENOENT;
+        return -1;
+    }
+
+    int flags = mode == SPAWN_PIPE_READ ? _O_RDONLY : _O_WRONLY;
+    int fd = _open_osfhandle((intptr_t)parent_handle, flags | _O_BINARY);
+    FILE *stream = fd >= 0 ? _fdopen(fd, mode == SPAWN_PIPE_READ ? "rb" : "wb") : NULL;
+    if (!stream) {
+        if (fd >= 0)
+            _close(fd);
+        else
+            CloseHandle(parent_handle);
+        TerminateJobObject(child.job, 1);
+        (void)child_finish(&child, INFINITE, 0);
+        return -1;
+    }
+    child_publish(&child);
+    result->stream = stream;
+    result->pid = (pid_t)child.process_info.dwProcessId;
+    return 0;
+}
+
+int spawn_pipe_open_write(struct spawn_pipe *pipe, const char *shell_cmd)
+{
+    return pipe_open(pipe, shell_cmd, SPAWN_PIPE_WRITE);
+}
+
+int spawn_pipe_open_read(struct spawn_pipe *pipe, const char *shell_cmd)
+{
+    return pipe_open(pipe, shell_cmd, SPAWN_PIPE_READ);
+}
+
+int spawn_pipe_close(struct spawn_pipe *pipe)
+{
+    if (!pipe || !pipe->stream)
+        return 0;
+    fclose(pipe->stream);
+    pipe->stream = NULL;
+    struct child_record *record = child_take(pipe->pid);
+    pipe->pid = 0;
+    if (!record)
+        return -1;
+    struct child_start child = {.process_info = {.hProcess = record->process}, .job = record->job};
+    free(record);
+    return child_finish(&child, INFINITE, 0);
+}
+
+int spawn_wait_child(pid_t pid)
+{
+    struct child_record *record = child_take(pid);
+    if (!record)
+        return -1;
+    struct child_start child = {.process_info = {.hProcess = record->process}, .job = record->job};
+    free(record);
+    return child_finish(&child, INFINITE, 0);
+}
+
+int spawn_wait_child_timeout(pid_t pid, int timeout_ms)
+{
+    struct child_record *record = child_take(pid);
+    if (!record)
+        return -1;
+    struct child_start child = {.process_info = {.hProcess = record->process}, .job = record->job};
+    free(record);
+    return child_finish(&child, timeout_ms < 0 ? INFINITE : (DWORD)timeout_ms, 1);
+}
+
+int spawn_reap_if_exited(pid_t pid)
+{
+    AcquireSRWLockShared(&child_lock);
+    struct child_record *record = children;
+    while (record && record->pid != pid)
+        record = record->next;
+    int exited = record && WaitForSingleObject(record->process, 0) == WAIT_OBJECT_0;
+    ReleaseSRWLockShared(&child_lock);
+    if (exited)
+        (void)spawn_wait_child(pid);
+    return exited;
+}
+
+char *spawn_capture_stdout(const char *const *argv, size_t max_bytes, int timeout_ms,
+                           size_t *out_len)
+{
+    if (!argv || !argv[0] || !out_len || timeout_ms <= 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    wchar_t *application = search_executable(argv[0]);
+    wchar_t *command_line = application ? argv_command_line(argv) : NULL;
+    if (!application || !command_line) {
+        free(application);
+        free(command_line);
+        return NULL;
+    }
+
+    SECURITY_ATTRIBUTES security = {.nLength = sizeof(security), .bInheritHandle = TRUE};
+    HANDLE read_handle;
+    HANDLE write_handle;
+    if (!CreatePipe(&read_handle, &write_handle, &security, 0)) {
+        free(application);
+        free(command_line);
+        return NULL;
+    }
+    SetHandleInformation(read_handle, HANDLE_FLAG_INHERIT, 0);
+    HANDLE null_handle =
+        CreateFileW(L"NUL", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
+                    &security, OPEN_EXISTING, 0, NULL);
+    struct child_start child;
+    int started = start_process(application, command_line, null_handle, write_handle, null_handle,
+                                NULL, &child);
+    CloseHandle(write_handle);
+    CloseHandle(null_handle);
+    free(application);
+    free(command_line);
+    if (started != 0) {
+        CloseHandle(read_handle);
+        return NULL;
+    }
+
+    struct buf output;
+    buf_init(&output);
+    long deadline = monotonic_ms() + timeout_ms;
+    int failed = 0;
+    for (;;) {
+        DWORD available = 0;
+        if (!PeekNamedPipe(read_handle, NULL, 0, NULL, &available, NULL)) {
+            if (GetLastError() == ERROR_BROKEN_PIPE)
+                break;
+            failed = 1;
+            break;
+        }
+        if (available) {
+            char chunk[65536];
+            DWORD request = available < sizeof(chunk) ? available : sizeof(chunk);
+            DWORD bytes_read = 0;
+            if (!ReadFile(read_handle, chunk, request, &bytes_read, NULL)) {
+                failed = 1;
+                break;
+            }
+            if ((size_t)bytes_read > max_bytes - output.len) {
+                failed = 1;
+                break;
+            }
+            buf_append(&output, chunk, bytes_read);
+            continue;
+        }
+        if (WaitForSingleObject(child.process_info.hProcess, 0) == WAIT_OBJECT_0)
+            break;
+        if (monotonic_ms() >= deadline) {
+            failed = 1;
+            break;
+        }
+        Sleep(2);
+    }
+    CloseHandle(read_handle);
+    int status = child_finish(&child, failed ? 0 : (DWORD)(deadline - monotonic_ms()), 1);
+    if (failed || status != 0 || output.len == 0) {
+        buf_free(&output);
+        return NULL;
+    }
+    *out_len = output.len;
+    return buf_steal(&output);
+}
+
+#endif /* _WIN32 */

--- a/src/system/spawn_win32.c
+++ b/src/system/spawn_win32.c
@@ -15,15 +15,11 @@
 #include "system/path.h"
 #include "system/spawn.h"
 
-struct child_record {
-    pid_t pid;
+struct spawn_process {
     HANDLE process;
     HANDLE job;
-    struct child_record *next;
+    int forced;
 };
-
-static SRWLOCK child_lock = SRWLOCK_INIT;
-static struct child_record *children;
 
 static wchar_t *utf8_to_wide(const char *text)
 {
@@ -262,29 +258,13 @@ static int child_finish(struct child_start *child, DWORD timeout_ms, int termina
     return wait == WAIT_OBJECT_0 ? (int)(exit_code & 0xff) : -1;
 }
 
-static void child_publish(struct child_start *child)
+static struct spawn_process *process_from_child(struct child_start *child)
 {
-    struct child_record *record = xmalloc(sizeof(*record));
-    record->pid = (pid_t)child->process_info.dwProcessId;
-    record->process = child->process_info.hProcess;
-    record->job = child->job;
-    AcquireSRWLockExclusive(&child_lock);
-    record->next = children;
-    children = record;
-    ReleaseSRWLockExclusive(&child_lock);
-}
-
-static struct child_record *child_take(pid_t pid)
-{
-    AcquireSRWLockExclusive(&child_lock);
-    struct child_record **link = &children;
-    while (*link && (*link)->pid != pid)
-        link = &(*link)->next;
-    struct child_record *record = *link;
-    if (record)
-        *link = record->next;
-    ReleaseSRWLockExclusive(&child_lock);
-    return record;
+    struct spawn_process *process = xmalloc(sizeof(*process));
+    process->process = child->process_info.hProcess;
+    process->job = child->job;
+    process->forced = 0;
+    return process;
 }
 
 static int compare_env(const void *left, const void *right)
@@ -375,13 +355,17 @@ int spawn_win32_bash_available(void)
     return started == 0 && child_finish(&child, 3000, 1) == 0;
 }
 
-int spawn_win32_start_bash(const char *command, char *const envp[], pid_t *pid, int *output_fd)
+struct spawn_process *spawn_process_start_bash(const char *shell, const char *argv0,
+                                               const char *command, char *const envp[],
+                                               int *output_fd)
 {
+    (void)shell;
+    (void)argv0;
     SECURITY_ATTRIBUTES security = {.nLength = sizeof(security), .bInheritHandle = TRUE};
     HANDLE read_handle;
     HANDLE write_handle;
     if (!CreatePipe(&read_handle, &write_handle, &security, 0))
-        return -1;
+        return NULL;
     SetHandleInformation(read_handle, HANDLE_FLAG_INHERIT, 0);
     HANDLE null_handle =
         CreateFileW(L"NUL", GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE,
@@ -402,110 +386,73 @@ int spawn_win32_start_bash(const char *command, char *const envp[], pid_t *pid, 
     if (started != 0) {
         CloseHandle(read_handle);
         errno = ENOENT;
-        return -1;
+        return NULL;
     }
 
-    int fd = _open_osfhandle((intptr_t)read_handle, _O_RDONLY | _O_BINARY);
+    int fd = _open_osfhandle((intptr_t)read_handle, _O_RDONLY | _O_BINARY | _O_NOINHERIT);
     if (fd < 0) {
         CloseHandle(read_handle);
         TerminateJobObject(child.job, 1);
         (void)child_finish(&child, INFINITE, 0);
-        return -1;
+        return NULL;
     }
-    child_publish(&child);
-    *pid = (pid_t)child.process_info.dwProcessId;
     *output_fd = fd;
-    return 0;
+    return process_from_child(&child);
 }
 
-void spawn_win32_terminate(pid_t pid)
+void spawn_process_terminate(struct spawn_process *process, int signal_number)
 {
-    AcquireSRWLockShared(&child_lock);
-    struct child_record *record = children;
-    while (record && record->pid != pid)
-        record = record->next;
-    if (record)
-        TerminateJobObject(record->job, 1);
-    ReleaseSRWLockShared(&child_lock);
+    (void)signal_number;
+    if (!process)
+        return;
+    int root_running = WaitForSingleObject(process->process, 0) == WAIT_TIMEOUT;
+    if (TerminateJobObject(process->job, 1) && root_running)
+        process->forced = 1;
 }
 
-int spawn_win32_exit_seen(pid_t pid, int *exit_seen)
+int spawn_process_exit_seen(struct spawn_process *process, int *exit_seen)
 {
-    AcquireSRWLockShared(&child_lock);
-    struct child_record *record = children;
-    while (record && record->pid != pid)
-        record = record->next;
-    if (!record) {
-        ReleaseSRWLockShared(&child_lock);
-        errno = ECHILD;
+    if (!process || !exit_seen) {
+        errno = EINVAL;
         return -1;
     }
-    if (WaitForSingleObject(record->process, 0) == WAIT_OBJECT_0)
+    DWORD wait = WaitForSingleObject(process->process, 0);
+    if (wait == WAIT_OBJECT_0) {
         *exit_seen = 1;
-    ReleaseSRWLockShared(&child_lock);
-    return 0;
-}
-
-pid_t spawn_win32_waitpid(pid_t pid, int *status, int options)
-{
-    AcquireSRWLockShared(&child_lock);
-    struct child_record *found = children;
-    while (found && found->pid != pid)
-        found = found->next;
-    if (!found) {
-        ReleaseSRWLockShared(&child_lock);
-        errno = ECHILD;
-        return -1;
+        return 0;
     }
-    DWORD wait = WaitForSingleObject(found->process, options & WNOHANG ? 0 : INFINITE);
-    ReleaseSRWLockShared(&child_lock);
     if (wait == WAIT_TIMEOUT)
         return 0;
-    if (wait != WAIT_OBJECT_0)
-        return -1;
+    errno = EIO;
+    return -1;
+}
 
-    struct child_record *record = child_take(pid);
-    if (!record) {
-        errno = ECHILD;
+int spawn_process_wait(struct spawn_process *process, struct spawn_status *status)
+{
+    if (!process || !status) {
+        errno = EINVAL;
         return -1;
     }
+    DWORD wait = WaitForSingleObject(process->process, INFINITE);
     DWORD exit_code = 1;
-    GetExitCodeProcess(record->process, &exit_code);
-    if (status)
-        *status = (int)(exit_code & 0xff);
-    CloseHandle(record->process);
-    CloseHandle(record->job);
-    free(record);
-    return pid;
+    if (wait == WAIT_OBJECT_0)
+        GetExitCodeProcess(process->process, &exit_code);
+    if (process->forced)
+        *status = (struct spawn_status){.end = SPAWN_END_FORCED};
+    else
+        *status = (struct spawn_status){.end = SPAWN_END_EXITED, .code = (int)(exit_code & 0xff)};
+    CloseHandle(process->process);
+    CloseHandle(process->job);
+    free(process);
+    if (wait == WAIT_OBJECT_0)
+        return 0;
+    errno = EIO;
+    return -1;
 }
 
 char *spawn_shell_cmd_force_utf8(char *shell_cmd)
 {
     return shell_cmd;
-}
-
-void spawn_parent_ignore_signals(struct spawn_signal_state *state)
-{
-    memset(state, 0, sizeof(*state));
-}
-
-void spawn_parent_restore_signals(const struct spawn_signal_state *state)
-{
-    (void)state;
-}
-
-void spawn_child_reset_signals(void)
-{
-}
-
-void spawn_child_redirect_stdio_to_null(void)
-{
-}
-
-void spawn_child_die_with_parent(pid_t parent_pid, int signal_number)
-{
-    (void)parent_pid;
-    (void)signal_number;
 }
 
 int spawn_shell_wait(const char *shell_cmd)
@@ -565,7 +512,7 @@ static int pipe_open(struct spawn_pipe *result, const char *shell_cmd, enum spaw
     }
 
     int flags = mode == SPAWN_PIPE_READ ? _O_RDONLY : _O_WRONLY;
-    int fd = _open_osfhandle((intptr_t)parent_handle, flags | _O_BINARY);
+    int fd = _open_osfhandle((intptr_t)parent_handle, flags | _O_BINARY | _O_NOINHERIT);
     FILE *stream = fd >= 0 ? _fdopen(fd, mode == SPAWN_PIPE_READ ? "rb" : "wb") : NULL;
     if (!stream) {
         if (fd >= 0)
@@ -576,9 +523,8 @@ static int pipe_open(struct spawn_pipe *result, const char *shell_cmd, enum spaw
         (void)child_finish(&child, INFINITE, 0);
         return -1;
     }
-    child_publish(&child);
     result->stream = stream;
-    result->pid = (pid_t)child.process_info.dwProcessId;
+    result->process = process_from_child(&child);
     return 0;
 }
 
@@ -598,46 +544,12 @@ int spawn_pipe_close(struct spawn_pipe *pipe)
         return 0;
     fclose(pipe->stream);
     pipe->stream = NULL;
-    struct child_record *record = child_take(pipe->pid);
-    pipe->pid = 0;
-    if (!record)
+    struct spawn_status status;
+    struct spawn_process *process = pipe->process;
+    pipe->process = NULL;
+    if (spawn_process_wait(process, &status) < 0)
         return -1;
-    struct child_start child = {.process_info = {.hProcess = record->process}, .job = record->job};
-    free(record);
-    return child_finish(&child, INFINITE, 0);
-}
-
-int spawn_wait_child(pid_t pid)
-{
-    struct child_record *record = child_take(pid);
-    if (!record)
-        return -1;
-    struct child_start child = {.process_info = {.hProcess = record->process}, .job = record->job};
-    free(record);
-    return child_finish(&child, INFINITE, 0);
-}
-
-int spawn_wait_child_timeout(pid_t pid, int timeout_ms)
-{
-    struct child_record *record = child_take(pid);
-    if (!record)
-        return -1;
-    struct child_start child = {.process_info = {.hProcess = record->process}, .job = record->job};
-    free(record);
-    return child_finish(&child, timeout_ms < 0 ? INFINITE : (DWORD)timeout_ms, 1);
-}
-
-int spawn_reap_if_exited(pid_t pid)
-{
-    AcquireSRWLockShared(&child_lock);
-    struct child_record *record = children;
-    while (record && record->pid != pid)
-        record = record->next;
-    int exited = record && WaitForSingleObject(record->process, 0) == WAIT_OBJECT_0;
-    ReleaseSRWLockShared(&child_lock);
-    if (exited)
-        (void)spawn_wait_child(pid);
-    return exited;
+    return status.end == SPAWN_END_EXITED ? status.code : 1;
 }
 
 char *spawn_capture_stdout(const char *const *argv, size_t max_bytes, int timeout_ms,

--- a/src/system/spawn_win32.c
+++ b/src/system/spawn_win32.c
@@ -222,7 +222,7 @@ static int start_process(const wchar_t *application, wchar_t *command_line, HAND
     }
 
     PROCESS_INFORMATION process_info;
-    win32_terminal_release();
+    win32_terminal_leave_for_child();
     BOOL created =
         CreateProcessW(application, command_line, NULL, NULL, TRUE,
                        CREATE_SUSPENDED | CREATE_UNICODE_ENVIRONMENT | EXTENDED_STARTUPINFO_PRESENT,
@@ -363,8 +363,8 @@ int spawn_win32_bash_available(void)
     wchar_t *bash = find_git_bash();
     if (!bash)
         return 0;
-    wchar_t *command_line = bash_command_line(
-        bash, "test -n \"$BASH_VERSION\" && cd /c && test \"$(pwd -W)\" = C:/");
+    wchar_t *command_line =
+        bash_command_line(bash, "test -n \"$BASH_VERSION\" && cd /c && test \"$(pwd -W)\" = C:/");
     struct child_start child;
     int started = command_line ? start_process(bash, command_line, GetStdHandle(STD_INPUT_HANDLE),
                                                GetStdHandle(STD_OUTPUT_HANDLE),

--- a/src/system/win32.c
+++ b/src/system/win32.c
@@ -242,6 +242,8 @@ struct console_state {
     DWORD output_mode;
     UINT input_code_page;
     UINT output_code_page;
+    int input_saved;
+    int output_saved;
     int input_changed;
     int output_changed;
 };
@@ -253,14 +255,21 @@ int hax_isatty(int fd)
     return terminal_windows_stream_kind(fd) != TERMINAL_STREAM_REDIRECTED;
 }
 
-void win32_terminal_release(void)
+void win32_terminal_leave_for_child(void)
 {
-    if (console_state.input_changed) {
+    if (console_state.input_saved) {
         SetConsoleMode(console_state.input, console_state.input_mode);
         SetConsoleCP(console_state.input_code_page);
         console_state.input_changed = 0;
     }
-    if (console_state.output_changed) {
+}
+
+void win32_terminal_release(void)
+{
+    /* Restore the immutable startup state even when another cleanup path already cleared the
+     * changed flags: termios teardown may subsequently have restored its saved VT mode. */
+    win32_terminal_leave_for_child();
+    if (console_state.output_saved) {
         SetConsoleMode(console_state.output, console_state.output_mode);
         SetConsoleOutputCP(console_state.output_code_page);
         console_state.output_changed = 0;
@@ -300,8 +309,6 @@ void win32_terminal_acquire(void)
 {
     DWORD mode;
     if (!console_state.output_changed && GetConsoleMode(console_state.output, &mode)) {
-        console_state.output_mode = mode;
-        console_state.output_code_page = GetConsoleOutputCP();
         DWORD vt_mode = mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | ENABLE_PROCESSED_OUTPUT;
         if (SetConsoleMode(console_state.output, vt_mode)) {
             SetConsoleOutputCP(CP_UTF8);
@@ -309,10 +316,8 @@ void win32_terminal_acquire(void)
         }
     }
     if (!console_state.input_changed && GetConsoleMode(console_state.input, &mode)) {
-        console_state.input_mode = mode;
-        console_state.input_code_page = GetConsoleCP();
+        /* Preserve the caller's Quick Edit bit so selection and host scrollback keep working. */
         DWORD vt_mode = mode | ENABLE_VIRTUAL_TERMINAL_INPUT | ENABLE_EXTENDED_FLAGS;
-        vt_mode &= ~ENABLE_QUICK_EDIT_MODE;
         if (SetConsoleMode(console_state.input, vt_mode)) {
             SetConsoleCP(CP_UTF8);
             console_state.input_changed = 1;
@@ -376,6 +381,14 @@ void win32_process_init(int *argc, char ***argv)
 
     console_state.input = GetStdHandle(STD_INPUT_HANDLE);
     console_state.output = GetStdHandle(STD_OUTPUT_HANDLE);
+    console_state.input_saved =
+        GetConsoleMode(console_state.input, &console_state.input_mode) != FALSE;
+    if (console_state.input_saved)
+        console_state.input_code_page = GetConsoleCP();
+    console_state.output_saved =
+        GetConsoleMode(console_state.output, &console_state.output_mode) != FALSE;
+    if (console_state.output_saved)
+        console_state.output_code_page = GetConsoleOutputCP();
     win32_terminal_acquire();
     atexit(win32_terminal_release);
     SetConsoleCtrlHandler(console_control_handler, TRUE);
@@ -1416,7 +1429,6 @@ int tcsetattr(int fd, int action, const struct termios *attributes)
         terminal_windows_stream_kind(fd) == TERMINAL_STREAM_MSYS_PTY)
         return 0;
     DWORD mode = attributes->input_mode | ENABLE_VIRTUAL_TERMINAL_INPUT | ENABLE_EXTENDED_FLAGS;
-    mode &= ~ENABLE_QUICK_EDIT_MODE;
     if (attributes->c_lflag & ICANON)
         mode |= ENABLE_LINE_INPUT;
     else
@@ -1464,6 +1476,26 @@ int ioctl(int fd, int request, ...)
     return 0;
 }
 
+static int console_input_ready(HANDLE handle)
+{
+    for (int i = 0; i < 64; i++) {
+        INPUT_RECORD record;
+        DWORD count;
+        if (!PeekConsoleInputW(handle, &record, 1, &count) || count == 0)
+            return 0;
+        if (record.EventType == KEY_EVENT && record.Event.KeyEvent.bKeyDown) {
+            WORD key = record.Event.KeyEvent.wVirtualKeyCode;
+            if (record.Event.KeyEvent.uChar.UnicodeChar != L'\0' && key != VK_SHIFT &&
+                key != VK_CONTROL && key != VK_MENU && key != VK_CAPITAL && key != VK_NUMLOCK &&
+                key != VK_SCROLL)
+                return 1;
+        }
+        if (!ReadConsoleInputW(handle, &record, 1, &count))
+            return 0;
+    }
+    return 0;
+}
+
 int poll(struct pollfd *fds, nfds_t count, int timeout_ms)
 {
     if (!fds || count == 0) {
@@ -1487,8 +1519,14 @@ int poll(struct pollfd *fds, nfds_t count, int timeout_ms)
                         fds[i].revents = POLLHUP;
                     else if (available)
                         fds[i].revents = POLLIN;
-                } else if (WaitForSingleObject(handle, 0) == WAIT_OBJECT_0) {
-                    fds[i].revents = POLLIN;
+                } else {
+                    DWORD console_mode;
+                    if (GetConsoleMode(handle, &console_mode)) {
+                        if (console_input_ready(handle))
+                            fds[i].revents = POLLIN;
+                    } else if (WaitForSingleObject(handle, 0) == WAIT_OBJECT_0) {
+                        fds[i].revents = POLLIN;
+                    }
                 }
             } else if (fds[i].events & POLLOUT) {
                 fds[i].revents = POLLOUT;

--- a/src/system/win32.c
+++ b/src/system/win32.c
@@ -1,0 +1,1580 @@
+/* SPDX-License-Identifier: MIT */
+#ifdef _WIN32
+
+#include "hax_win32.h"
+
+#undef access
+#undef chdir
+#undef chmod
+#undef getcwd
+#undef getline
+#undef gmtime_r
+#undef kill
+#undef lstat
+#undef localtime_r
+#undef readlink
+#undef fclose
+#undef fflush
+#undef fopen
+#undef freopen
+#undef mkdir
+#undef mkdtemp
+#undef mkstemp
+#undef open
+#undef open_memstream
+#undef pipe
+#undef fcntl
+#undef realpath
+#undef remove
+#undef rename
+#undef rmdir
+#undef stat
+#undef symlink
+#undef unlink
+#undef utimensat
+#undef wcwidth
+
+#include <bcrypt.h>
+#include <direct.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <getopt.h>
+#include <io.h>
+#include <libgen.h>
+#include <poll.h>
+#include <shellapi.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <termios.h>
+#include <wchar.h>
+#include <windows.h>
+#include <winioctl.h>
+#include <sys/file.h>
+#include <sys/ioctl.h>
+#include <sys/locking.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>
+
+#include "util.h"
+#include "terminal/windows.h"
+
+static void set_errno_from_win32(DWORD error)
+{
+    switch (error) {
+    case ERROR_FILE_NOT_FOUND:
+    case ERROR_PATH_NOT_FOUND:
+    case ERROR_INVALID_DRIVE:
+        errno = ENOENT;
+        break;
+    case ERROR_ACCESS_DENIED:
+    case ERROR_SHARING_VIOLATION:
+    case ERROR_LOCK_VIOLATION:
+        errno = EACCES;
+        break;
+    case ERROR_ALREADY_EXISTS:
+    case ERROR_FILE_EXISTS:
+        errno = EEXIST;
+        break;
+    case ERROR_DIRECTORY:
+        errno = ENOTDIR;
+        break;
+    case ERROR_DIR_NOT_EMPTY:
+        errno = ENOTEMPTY;
+        break;
+    case ERROR_FILENAME_EXCED_RANGE:
+        errno = ENAMETOOLONG;
+        break;
+    case ERROR_NOT_ENOUGH_MEMORY:
+    case ERROR_OUTOFMEMORY:
+        errno = ENOMEM;
+        break;
+    default:
+        errno = EIO;
+        break;
+    }
+}
+
+static wchar_t *utf8_to_wide(const char *text)
+{
+    if (!text) {
+        errno = EINVAL;
+        return NULL;
+    }
+    int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text, -1, NULL, 0);
+    if (length <= 0) {
+        set_errno_from_win32(GetLastError());
+        return NULL;
+    }
+    wchar_t *wide = malloc((size_t)length * sizeof(*wide));
+    if (!wide) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    if (!MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text, -1, wide, length)) {
+        set_errno_from_win32(GetLastError());
+        free(wide);
+        return NULL;
+    }
+    return wide;
+}
+
+static char *wide_to_utf8(const wchar_t *text)
+{
+    int length = WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, text, -1, NULL, 0, NULL, NULL);
+    if (length <= 0) {
+        set_errno_from_win32(GetLastError());
+        return NULL;
+    }
+    char *utf8 = malloc((size_t)length);
+    if (!utf8) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    if (!WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, text, -1, utf8, length, NULL, NULL)) {
+        set_errno_from_win32(GetLastError());
+        free(utf8);
+        return NULL;
+    }
+    return utf8;
+}
+
+static int ascii_alpha(char value)
+{
+    return (value >= 'A' && value <= 'Z') || (value >= 'a' && value <= 'z');
+}
+
+static wchar_t *path_to_wide(const char *path)
+{
+    if (path && strcmp(path, "/dev/null") == 0)
+        return _wcsdup(L"NUL");
+    if (path && strcmp(path, "/dev/tty") == 0)
+        return _wcsdup(L"CON");
+    if (path && strncmp(path, "/tmp", 4) == 0 && (path[4] == '\0' || path[4] == '/')) {
+        wchar_t temporary[32768];
+        DWORD length = GetTempPathW(32768, temporary);
+        wchar_t *suffix = utf8_to_wide(path + 4);
+        if (!length || length >= 32768 || !suffix) {
+            free(suffix);
+            errno = EIO;
+            return NULL;
+        }
+        while (length > 0 && (temporary[length - 1] == L'\\' || temporary[length - 1] == L'/'))
+            temporary[--length] = L'\0';
+        size_t needed = length + wcslen(suffix) + 1;
+        wchar_t *result = malloc(needed * sizeof(*result));
+        if (result) {
+            wcscpy(result, temporary);
+            wcscat(result, suffix);
+            for (wchar_t *cursor = result; *cursor; cursor++)
+                if (*cursor == L'/')
+                    *cursor = L'\\';
+        }
+        free(suffix);
+        return result;
+    }
+    char *native = NULL;
+    if (path && path[0] == '/' && ascii_alpha(path[1]) &&
+        (path[2] == '/' || path[2] == '\\' || path[2] == '\0')) {
+        size_t length = strlen(path);
+        native = malloc(length + 2);
+        if (!native) {
+            errno = ENOMEM;
+            return NULL;
+        }
+        native[0] = path[1] >= 'a' ? (char)(path[1] - 'a' + 'A') : path[1];
+        native[1] = ':';
+        memcpy(native + 2, path + 2, length - 1);
+    } else if (path && path[0] == '/' && path[1] == '/') {
+        native = _strdup(path);
+        if (native) {
+            native[0] = '\\';
+            native[1] = '\\';
+        }
+    } else if (path && path[0] == '/') {
+        errno = ENOTSUP;
+        return NULL;
+    } else {
+        native = path ? _strdup(path) : NULL;
+    }
+    if (!native) {
+        errno = path ? ENOMEM : EINVAL;
+        return NULL;
+    }
+    for (char *cursor = native; *cursor; cursor++)
+        if (*cursor == '/')
+            *cursor = '\\';
+    wchar_t *wide = utf8_to_wide(native);
+    free(native);
+    return wide;
+}
+
+static char *path_from_wide(const wchar_t *path)
+{
+    char *utf8 = wide_to_utf8(path);
+    if (!utf8)
+        return NULL;
+    for (char *cursor = utf8; *cursor; cursor++)
+        if (*cursor == '\\')
+            *cursor = '/';
+
+    if (ascii_alpha(utf8[0]) && utf8[1] == ':') {
+        size_t length = strlen(utf8);
+        char *canonical = malloc(length + 2);
+        if (!canonical) {
+            free(utf8);
+            errno = ENOMEM;
+            return NULL;
+        }
+        canonical[0] = '/';
+        canonical[1] = utf8[0] >= 'A' ? (char)(utf8[0] - 'A' + 'a') : utf8[0];
+        memcpy(canonical + 2, utf8 + 2, length - 1);
+        free(utf8);
+        return canonical;
+    }
+    return utf8;
+}
+
+struct console_state {
+    HANDLE input;
+    HANDLE output;
+    DWORD input_mode;
+    DWORD output_mode;
+    UINT input_code_page;
+    UINT output_code_page;
+    int input_changed;
+    int output_changed;
+};
+
+static struct console_state console_state;
+
+int hax_isatty(int fd)
+{
+    return terminal_windows_stream_kind(fd) != TERMINAL_STREAM_REDIRECTED;
+}
+
+void win32_terminal_release(void)
+{
+    if (console_state.input_changed) {
+        SetConsoleMode(console_state.input, console_state.input_mode);
+        SetConsoleCP(console_state.input_code_page);
+        console_state.input_changed = 0;
+    }
+    if (console_state.output_changed) {
+        SetConsoleMode(console_state.output, console_state.output_mode);
+        SetConsoleOutputCP(console_state.output_code_page);
+        console_state.output_changed = 0;
+    }
+}
+
+static BOOL WINAPI console_control_handler(DWORD control)
+{
+    (void)control;
+    win32_terminal_release();
+    return FALSE;
+}
+
+static char *normalize_environment_path(const char *path)
+{
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return NULL;
+    char *normalized = path_from_wide(wide);
+    free(wide);
+    return normalized;
+}
+
+static void normalize_path_environment(const char *name)
+{
+    const char *value = getenv(name);
+    if (!value || !*value)
+        return;
+    char *normalized = normalize_environment_path(value);
+    if (normalized) {
+        _putenv_s(name, normalized);
+        free(normalized);
+    }
+}
+
+void win32_terminal_acquire(void)
+{
+    DWORD mode;
+    if (!console_state.output_changed && GetConsoleMode(console_state.output, &mode)) {
+        console_state.output_mode = mode;
+        console_state.output_code_page = GetConsoleOutputCP();
+        DWORD vt_mode = mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING | ENABLE_PROCESSED_OUTPUT;
+        if (SetConsoleMode(console_state.output, vt_mode)) {
+            SetConsoleOutputCP(CP_UTF8);
+            console_state.output_changed = 1;
+        }
+    }
+    if (!console_state.input_changed && GetConsoleMode(console_state.input, &mode)) {
+        console_state.input_mode = mode;
+        console_state.input_code_page = GetConsoleCP();
+        DWORD vt_mode = mode | ENABLE_VIRTUAL_TERMINAL_INPUT | ENABLE_EXTENDED_FLAGS;
+        vt_mode &= ~ENABLE_QUICK_EDIT_MODE;
+        if (SetConsoleMode(console_state.input, vt_mode)) {
+            SetConsoleCP(CP_UTF8);
+            console_state.input_changed = 1;
+        }
+    }
+}
+
+void win32_process_init(int *argc, char ***argv)
+{
+    int wide_argc = 0;
+    wchar_t **wide_argv = CommandLineToArgvW(GetCommandLineW(), &wide_argc);
+    if (wide_argv) {
+        char **utf8_argv = calloc((size_t)wide_argc + 1, sizeof(*utf8_argv));
+        if (utf8_argv) {
+            int converted = 1;
+            for (int i = 0; i < wide_argc; i++) {
+                utf8_argv[i] = wide_to_utf8(wide_argv[i]);
+                converted &= utf8_argv[i] != NULL;
+            }
+            if (converted) {
+                *argc = wide_argc;
+                *argv = utf8_argv;
+            } else {
+                for (int i = 0; i < wide_argc; i++)
+                    free(utf8_argv[i]);
+                free(utf8_argv);
+            }
+        }
+        LocalFree(wide_argv);
+    }
+
+    _setmode(STDIN_FILENO, _O_BINARY);
+    _setmode(STDOUT_FILENO, _O_BINARY);
+    _setmode(STDERR_FILENO, _O_BINARY);
+
+    if (!getenv("HOME") || !*getenv("HOME")) {
+        const char *profile = getenv("USERPROFILE");
+        char *home = profile ? normalize_environment_path(profile) : NULL;
+        if (home) {
+            _putenv_s("HOME", home);
+            free(home);
+        }
+    } else {
+        normalize_path_environment("HOME");
+    }
+    normalize_path_environment("XDG_CONFIG_HOME");
+    normalize_path_environment("XDG_STATE_HOME");
+    normalize_path_environment("XDG_CACHE_HOME");
+    if (!getenv("TMPDIR") || !*getenv("TMPDIR")) {
+        const char *temporary = getenv("TEMP");
+        if (!temporary || !*temporary)
+            temporary = getenv("TMP");
+        char *normalized = temporary ? normalize_environment_path(temporary) : NULL;
+        if (normalized) {
+            _putenv_s("TMPDIR", normalized);
+            free(normalized);
+        }
+    } else {
+        normalize_path_environment("TMPDIR");
+    }
+
+    console_state.input = GetStdHandle(STD_INPUT_HANDLE);
+    console_state.output = GetStdHandle(STD_OUTPUT_HANDLE);
+    win32_terminal_acquire();
+    atexit(win32_terminal_release);
+    SetConsoleCtrlHandler(console_control_handler, TRUE);
+}
+
+int setenv(const char *name, const char *value, int overwrite)
+{
+    if (!overwrite && getenv(name))
+        return 0;
+    return _putenv_s(name, value);
+}
+
+int unsetenv(const char *name)
+{
+    return _putenv_s(name, "");
+}
+
+int clock_gettime(int clock_id, struct timespec *time_value)
+{
+    if (!time_value) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (clock_id == CLOCK_REALTIME) {
+        timespec_get(time_value, TIME_UTC);
+        return 0;
+    }
+    static LARGE_INTEGER frequency;
+    LARGE_INTEGER counter;
+    if (!frequency.QuadPart)
+        QueryPerformanceFrequency(&frequency);
+    QueryPerformanceCounter(&counter);
+    time_value->tv_sec = (time_t)(counter.QuadPart / frequency.QuadPart);
+    time_value->tv_nsec =
+        (long)((counter.QuadPart % frequency.QuadPart) * 1000000000LL / frequency.QuadPart);
+    return 0;
+}
+
+int nanosleep(const struct timespec *request, struct timespec *remaining)
+{
+    (void)remaining;
+    if (!request || request->tv_sec < 0 || request->tv_nsec < 0 ||
+        request->tv_nsec >= 1000000000L) {
+        errno = EINVAL;
+        return -1;
+    }
+    uint64_t milliseconds =
+        (uint64_t)request->tv_sec * 1000 + ((uint64_t)request->tv_nsec + 999999) / 1000000;
+    Sleep(milliseconds > UINT32_MAX ? UINT32_MAX : (DWORD)milliseconds);
+    return 0;
+}
+
+void hax_sleep_ms(long milliseconds)
+{
+    if (milliseconds > 0)
+        Sleep((DWORD)milliseconds);
+}
+
+ssize_t hax_getline(char **line, size_t *capacity, FILE *stream)
+{
+    if (!line || !capacity || !stream) {
+        errno = EINVAL;
+        return -1;
+    }
+    if (!*line || *capacity == 0) {
+        *capacity = 128;
+        *line = malloc(*capacity);
+        if (!*line)
+            return -1;
+    }
+    size_t length = 0;
+    int byte;
+    while ((byte = fgetc(stream)) != EOF) {
+        if (length + 1 >= *capacity) {
+            size_t next_capacity = *capacity > SIZE_MAX / 2 ? SIZE_MAX : *capacity * 2;
+            if (next_capacity <= *capacity) {
+                errno = EOVERFLOW;
+                return -1;
+            }
+            char *next = realloc(*line, next_capacity);
+            if (!next)
+                return -1;
+            *line = next;
+            *capacity = next_capacity;
+        }
+        (*line)[length++] = (char)byte;
+        if (byte == '\n')
+            break;
+    }
+    if (length == 0)
+        return -1;
+    (*line)[length] = '\0';
+    return (ssize_t)length;
+}
+
+struct tm *hax_gmtime_r(const time_t *time_value, struct tm *result)
+{
+    return gmtime_s(result, time_value) == 0 ? result : NULL;
+}
+
+struct tm *hax_localtime_r(const time_t *time_value, struct tm *result)
+{
+    return localtime_s(result, time_value) == 0 ? result : NULL;
+}
+
+struct hax_reparse_data {
+    ULONG tag;
+    USHORT data_length;
+    USHORT reserved;
+    union {
+        struct {
+            USHORT substitute_offset;
+            USHORT substitute_length;
+            USHORT print_offset;
+            USHORT print_length;
+            ULONG flags;
+            WCHAR path[1];
+        } symbolic_link;
+        struct {
+            USHORT substitute_offset;
+            USHORT substitute_length;
+            USHORT print_offset;
+            USHORT print_length;
+            WCHAR path[1];
+        } mount_point;
+    } data;
+};
+
+ssize_t hax_readlink(const char *path, char *buffer, size_t capacity)
+{
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return -1;
+    HANDLE handle =
+        CreateFileW(wide, 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL,
+                    OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
+    free(wide);
+    if (handle == INVALID_HANDLE_VALUE) {
+        set_errno_from_win32(GetLastError());
+        return -1;
+    }
+
+    unsigned char raw[MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
+    DWORD bytes_returned;
+    BOOL read = DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, NULL, 0, raw, sizeof(raw),
+                                &bytes_returned, NULL);
+    CloseHandle(handle);
+    if (!read) {
+        set_errno_from_win32(GetLastError());
+        return -1;
+    }
+
+    struct hax_reparse_data *reparse = (struct hax_reparse_data *)raw;
+    const wchar_t *target;
+    size_t target_length;
+    if (reparse->tag == IO_REPARSE_TAG_SYMLINK) {
+        const USHORT offset = reparse->data.symbolic_link.print_length
+                                  ? reparse->data.symbolic_link.print_offset
+                                  : reparse->data.symbolic_link.substitute_offset;
+        const USHORT length = reparse->data.symbolic_link.print_length
+                                  ? reparse->data.symbolic_link.print_length
+                                  : reparse->data.symbolic_link.substitute_length;
+        target = reparse->data.symbolic_link.path + offset / sizeof(wchar_t);
+        target_length = length / sizeof(wchar_t);
+    } else if (reparse->tag == IO_REPARSE_TAG_MOUNT_POINT) {
+        const USHORT offset = reparse->data.mount_point.print_length
+                                  ? reparse->data.mount_point.print_offset
+                                  : reparse->data.mount_point.substitute_offset;
+        const USHORT length = reparse->data.mount_point.print_length
+                                  ? reparse->data.mount_point.print_length
+                                  : reparse->data.mount_point.substitute_length;
+        target = reparse->data.mount_point.path + offset / sizeof(wchar_t);
+        target_length = length / sizeof(wchar_t);
+    } else {
+        errno = EINVAL;
+        return -1;
+    }
+
+    wchar_t *terminated = malloc((target_length + 1) * sizeof(*terminated));
+    if (!terminated) {
+        errno = ENOMEM;
+        return -1;
+    }
+    memcpy(terminated, target, target_length * sizeof(*terminated));
+    terminated[target_length] = L'\0';
+    wchar_t *normalized = terminated;
+    if (wcsncmp(normalized, L"\\??\\UNC\\", 8) == 0) {
+        normalized[6] = L'\\';
+        normalized += 6;
+    } else if (wcsncmp(normalized, L"\\??\\", 4) == 0) {
+        normalized += 4;
+    }
+    char *canonical = path_from_wide(normalized);
+    free(terminated);
+    if (!canonical)
+        return -1;
+    size_t bytes = strlen(canonical);
+    if (bytes > capacity) {
+        free(canonical);
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+    memcpy(buffer, canonical, bytes);
+    free(canonical);
+    return (ssize_t)bytes;
+}
+
+static FILETIME timespec_to_filetime(const struct timespec *time_value)
+{
+    uint64_t ticks = ((uint64_t)time_value->tv_sec + 11644473600ULL) * 10000000ULL +
+                     (uint64_t)time_value->tv_nsec / 100;
+    FILETIME file_time = {.dwLowDateTime = (DWORD)ticks, .dwHighDateTime = (DWORD)(ticks >> 32)};
+    return file_time;
+}
+
+int futimens(int fd, const struct timespec times[2])
+{
+    HANDLE handle = (HANDLE)_get_osfhandle(fd);
+    if (handle == INVALID_HANDLE_VALUE) {
+        errno = EBADF;
+        return -1;
+    }
+    FILETIME access_time;
+    FILETIME write_time;
+    FILETIME *access_ptr = NULL;
+    FILETIME *write_ptr = NULL;
+    if (!times) {
+        GetSystemTimeAsFileTime(&access_time);
+        write_time = access_time;
+        access_ptr = &access_time;
+        write_ptr = &write_time;
+    } else {
+        if (times[0].tv_nsec != UTIME_OMIT) {
+            access_time = timespec_to_filetime(&times[0]);
+            access_ptr = &access_time;
+        }
+        if (times[1].tv_nsec != UTIME_OMIT) {
+            write_time = timespec_to_filetime(&times[1]);
+            write_ptr = &write_time;
+        }
+    }
+    if (!SetFileTime(handle, NULL, access_ptr, write_ptr)) {
+        set_errno_from_win32(GetLastError());
+        return -1;
+    }
+    return 0;
+}
+
+int hax_utimensat(int directory_fd, const char *path, const struct timespec times[2], int flags)
+{
+    (void)flags;
+    if (directory_fd != AT_FDCWD) {
+        errno = ENOTSUP;
+        return -1;
+    }
+    int fd = hax_open(path, O_RDWR);
+    if (fd < 0)
+        return -1;
+    int result = futimens(fd, times);
+    _close(fd);
+    return result;
+}
+
+int hax_pipe(int fds[2])
+{
+    return _pipe(fds, 65536, _O_BINARY | _O_NOINHERIT);
+}
+
+int hax_fcntl(int fd, int command, ...)
+{
+    if (command == F_GETFL)
+        return 0;
+    if (command == F_SETFD || command == F_SETFL)
+        return 0;
+    (void)fd;
+    errno = EINVAL;
+    return -1;
+}
+
+int hax_wcwidth(wchar_t codepoint)
+{
+    if (codepoint == 0)
+        return 0;
+    if (codepoint < 0x20 || (codepoint >= 0x7f && codepoint < 0xa0))
+        return -1;
+    WORD type = 0;
+    if (GetStringTypeW(CT_CTYPE3, &codepoint, 1, &type) &&
+        (type & (C3_NONSPACING | C3_DIACRITIC | C3_VOWELMARK)))
+        return 0;
+    if ((codepoint >= 0x1100 && codepoint <= 0x115f) ||
+        (codepoint >= 0x2e80 && codepoint <= 0xa4cf) ||
+        (codepoint >= 0xac00 && codepoint <= 0xd7a3) ||
+        (codepoint >= 0xf900 && codepoint <= 0xfaff) ||
+        (codepoint >= 0xfe10 && codepoint <= 0xfe6f) ||
+        (codepoint >= 0xff00 && codepoint <= 0xff60) ||
+        (codepoint >= 0xffe0 && codepoint <= 0xffe6))
+        return 2;
+    return 1;
+}
+
+int hax_open(const char *path, int flags, ...)
+{
+    int mode = _S_IREAD | _S_IWRITE;
+    if (flags & O_CREAT) {
+        va_list args;
+        va_start(args, flags);
+        mode = va_arg(args, int);
+        va_end(args);
+    }
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return -1;
+    int fd = _wopen(wide, flags | _O_BINARY | _O_NOINHERIT, mode);
+    free(wide);
+    return fd;
+}
+
+static char *binary_mode(const char *mode)
+{
+    return strchr(mode, 'b') ? _strdup(mode) : xasprintf("%sb", mode);
+}
+
+FILE *hax_fopen(const char *path, const char *mode)
+{
+    wchar_t *wide_path = path_to_wide(path);
+    char *binary = binary_mode(mode);
+    wchar_t *wide_mode = binary ? utf8_to_wide(binary) : NULL;
+    free(binary);
+    if (!wide_path || !wide_mode) {
+        free(wide_path);
+        free(wide_mode);
+        return NULL;
+    }
+    FILE *file = _wfopen(wide_path, wide_mode);
+    free(wide_path);
+    free(wide_mode);
+    return file;
+}
+
+FILE *hax_freopen(const char *path, const char *mode, FILE *stream)
+{
+    wchar_t *wide_path = path_to_wide(path);
+    char *binary = binary_mode(mode);
+    wchar_t *wide_mode = binary ? utf8_to_wide(binary) : NULL;
+    free(binary);
+    if (!wide_path || !wide_mode) {
+        free(wide_path);
+        free(wide_mode);
+        return NULL;
+    }
+    FILE *file = _wfreopen(wide_path, wide_mode, stream);
+    free(wide_path);
+    free(wide_mode);
+    return file;
+}
+
+struct memory_stream {
+    FILE *stream;
+    char **buffer;
+    size_t *length;
+    struct memory_stream *next;
+};
+
+static SRWLOCK memory_stream_lock = SRWLOCK_INIT;
+static struct memory_stream *memory_streams;
+
+FILE *hax_open_memstream(char **buffer, size_t *length)
+{
+    if (!buffer || !length) {
+        errno = EINVAL;
+        return NULL;
+    }
+    FILE *stream = tmpfile();
+    if (!stream)
+        return NULL;
+    struct memory_stream *entry = malloc(sizeof(*entry));
+    if (!entry) {
+        fclose(stream);
+        errno = ENOMEM;
+        return NULL;
+    }
+    *buffer = NULL;
+    *length = 0;
+    *entry = (struct memory_stream){.stream = stream, .buffer = buffer, .length = length};
+    AcquireSRWLockExclusive(&memory_stream_lock);
+    entry->next = memory_streams;
+    memory_streams = entry;
+    ReleaseSRWLockExclusive(&memory_stream_lock);
+    return stream;
+}
+
+int hax_fflush(FILE *stream)
+{
+    int result = fflush(stream);
+    if (!stream)
+        return result;
+
+    AcquireSRWLockExclusive(&memory_stream_lock);
+    struct memory_stream *entry = memory_streams;
+    while (entry && entry->stream != stream)
+        entry = entry->next;
+    if (entry && result == 0) {
+        __int64 position = _ftelli64(stream);
+        if (position >= 0 && _fseeki64(stream, 0, SEEK_SET) == 0) {
+            char *data = malloc((size_t)position + 1);
+            if (data) {
+                size_t bytes_read = fread(data, 1, (size_t)position, stream);
+                data[bytes_read] = '\0';
+                free(*entry->buffer);
+                *entry->buffer = data;
+                *entry->length = bytes_read;
+                if (_fseeki64(stream, position, SEEK_SET) != 0)
+                    result = -1;
+            } else {
+                errno = ENOMEM;
+                result = -1;
+            }
+        } else {
+            result = -1;
+        }
+    }
+    ReleaseSRWLockExclusive(&memory_stream_lock);
+    return result;
+}
+
+int hax_fclose(FILE *stream)
+{
+    int result = hax_fflush(stream);
+    AcquireSRWLockExclusive(&memory_stream_lock);
+    struct memory_stream **link = &memory_streams;
+    while (*link && (*link)->stream != stream)
+        link = &(*link)->next;
+    struct memory_stream *entry = *link;
+    if (entry)
+        *link = entry->next;
+    ReleaseSRWLockExclusive(&memory_stream_lock);
+    if (fclose(stream) != 0)
+        result = -1;
+    free(entry);
+    return result;
+}
+
+int hax_access(const char *path, int mode)
+{
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return -1;
+    int result = _waccess(wide, mode == X_OK ? F_OK : mode);
+    free(wide);
+    return result;
+}
+
+int hax_chdir(const char *path)
+{
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return -1;
+    int result = _wchdir(wide);
+    free(wide);
+    return result;
+}
+
+int hax_chmod(const char *path, int mode)
+{
+    (void)mode;
+    return hax_access(path, F_OK);
+}
+
+char *hax_getcwd(char *buffer, int size)
+{
+    wchar_t *wide = _wgetcwd(NULL, 0);
+    if (!wide)
+        return NULL;
+    char *canonical = path_from_wide(wide);
+    free(wide);
+    if (!canonical)
+        return NULL;
+    size_t needed = strlen(canonical) + 1;
+    if (!buffer) {
+        if (size > 0 && needed > (size_t)size) {
+            free(canonical);
+            errno = ERANGE;
+            return NULL;
+        }
+        return canonical;
+    }
+    if (size <= 0 || needed > (size_t)size) {
+        free(canonical);
+        errno = ERANGE;
+        return NULL;
+    }
+    memcpy(buffer, canonical, needed);
+    free(canonical);
+    return buffer;
+}
+
+int hax_mkdir(const char *path)
+{
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return -1;
+    int result = _wmkdir(wide);
+    free(wide);
+    return result;
+}
+
+int hax_rename(const char *old_path, const char *new_path)
+{
+    wchar_t *wide_old = path_to_wide(old_path);
+    wchar_t *wide_new = path_to_wide(new_path);
+    if (!wide_old || !wide_new) {
+        free(wide_old);
+        free(wide_new);
+        return -1;
+    }
+    DWORD destination_attributes = GetFileAttributesW(wide_new);
+    BOOL moved = destination_attributes != INVALID_FILE_ATTRIBUTES
+                     ? ReplaceFileW(wide_new, wide_old, NULL, REPLACEFILE_WRITE_THROUGH, NULL, NULL)
+                     : MoveFileExW(wide_old, wide_new, MOVEFILE_WRITE_THROUGH);
+    if (!moved) {
+        moved = MoveFileExW(wide_old, wide_new, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH);
+        if (!moved)
+            set_errno_from_win32(GetLastError());
+    }
+    free(wide_old);
+    free(wide_new);
+    return moved ? 0 : -1;
+}
+
+static int path_delete(const char *path, int directory)
+{
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return -1;
+    BOOL removed = directory ? RemoveDirectoryW(wide) : DeleteFileW(wide);
+    if (!removed)
+        set_errno_from_win32(GetLastError());
+    free(wide);
+    return removed ? 0 : -1;
+}
+
+int hax_remove(const char *path)
+{
+    if (hax_unlink(path) == 0)
+        return 0;
+    return hax_rmdir(path);
+}
+
+int hax_rmdir(const char *path)
+{
+    return path_delete(path, 1);
+}
+
+int hax_unlink(const char *path)
+{
+    return path_delete(path, 0);
+}
+
+int hax_stat(const char *path, struct stat *status)
+{
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return -1;
+    struct _stat64 native;
+    int result = _wstat64(wide, &native);
+    free(wide);
+    if (result != 0)
+        return result;
+    memset(status, 0, sizeof(*status));
+    status->st_dev = native.st_dev;
+    status->st_ino = native.st_ino;
+    status->st_mode = native.st_mode;
+    status->st_nlink = native.st_nlink;
+    status->st_uid = native.st_uid;
+    status->st_gid = native.st_gid;
+    status->st_rdev = native.st_rdev;
+    status->st_size = native.st_size;
+    status->st_atime = native.st_atime;
+    status->st_mtime = native.st_mtime;
+    status->st_ctime = native.st_ctime;
+    return 0;
+}
+
+int hax_lstat(const char *path, struct stat *status)
+{
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return -1;
+    DWORD attributes = GetFileAttributesW(wide);
+    free(wide);
+    if (attributes == INVALID_FILE_ATTRIBUTES) {
+        set_errno_from_win32(GetLastError());
+        return -1;
+    }
+    if (attributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+        memset(status, 0, sizeof(*status));
+        status->st_mode = S_IFLNK;
+        char target[32768];
+        ssize_t target_length = hax_readlink(path, target, sizeof(target));
+        if (target_length < 0)
+            return -1;
+        status->st_size = target_length;
+        return 0;
+    }
+    return hax_stat(path, status);
+}
+
+int hax_symlink(const char *target, const char *link_path)
+{
+    wchar_t *wide_target = path_to_wide(target);
+    wchar_t *wide_link = path_to_wide(link_path);
+    if (!wide_target || !wide_link) {
+        free(wide_target);
+        free(wide_link);
+        return -1;
+    }
+    DWORD attributes = GetFileAttributesW(wide_target);
+    DWORD flags = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+    if (attributes != INVALID_FILE_ATTRIBUTES && attributes & FILE_ATTRIBUTE_DIRECTORY)
+        flags |= SYMBOLIC_LINK_FLAG_DIRECTORY;
+    BOOLEAN created = CreateSymbolicLinkW(wide_link, wide_target, flags);
+    if (!created)
+        set_errno_from_win32(GetLastError());
+    free(wide_target);
+    free(wide_link);
+    return created ? 0 : -1;
+}
+
+char *hax_realpath(const char *path, char *resolved)
+{
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return NULL;
+    DWORD needed = GetFullPathNameW(wide, 0, NULL, NULL);
+    if (!needed) {
+        set_errno_from_win32(GetLastError());
+        free(wide);
+        return NULL;
+    }
+    wchar_t *full = malloc((size_t)needed * sizeof(*full));
+    if (!full) {
+        free(wide);
+        errno = ENOMEM;
+        return NULL;
+    }
+    if (!GetFullPathNameW(wide, needed, full, NULL)) {
+        set_errno_from_win32(GetLastError());
+        free(full);
+        free(wide);
+        return NULL;
+    }
+    free(wide);
+    char *canonical = path_from_wide(full);
+    free(full);
+    if (!canonical)
+        return NULL;
+    if (!resolved)
+        return canonical;
+    strcpy(resolved, canonical);
+    free(canonical);
+    return resolved;
+}
+
+char *hax_search_path(const char *name)
+{
+    wchar_t *wide_name = utf8_to_wide(name);
+    if (!wide_name)
+        return NULL;
+    DWORD length = SearchPathW(NULL, wide_name, NULL, 0, NULL, NULL);
+    if (!length) {
+        free(wide_name);
+        return NULL;
+    }
+    wchar_t *wide_path = malloc(((size_t)length + 1) * sizeof(*wide_path));
+    if (!wide_path) {
+        free(wide_name);
+        return NULL;
+    }
+    if (!SearchPathW(NULL, wide_name, NULL, length + 1, wide_path, NULL)) {
+        free(wide_path);
+        free(wide_name);
+        return NULL;
+    }
+    free(wide_name);
+    char *path = path_from_wide(wide_path);
+    free(wide_path);
+    return path;
+}
+
+static int fill_random(void *data, size_t length)
+{
+    return BCryptGenRandom(NULL, data, (ULONG)length, BCRYPT_USE_SYSTEM_PREFERRED_RNG) == 0 ? 0
+                                                                                            : -1;
+}
+
+int hax_mkstemp(char *path_template)
+{
+    size_t length = path_template ? strlen(path_template) : 0;
+    if (length < 6 || strcmp(path_template + length - 6, "XXXXXX") != 0) {
+        errno = EINVAL;
+        return -1;
+    }
+    static const char alphabet[] = "abcdefghijklmnopqrstuvwxyz0123456789";
+    for (int attempt = 0; attempt < 128; attempt++) {
+        unsigned char random[6];
+        if (fill_random(random, sizeof(random)) != 0) {
+            errno = EIO;
+            return -1;
+        }
+        for (size_t i = 0; i < sizeof(random); i++)
+            path_template[length - 6 + i] = alphabet[random[i] % (sizeof(alphabet) - 1)];
+        int fd = hax_open(path_template, O_CREAT | O_EXCL | O_RDWR, 0600);
+        if (fd >= 0)
+            return fd;
+        if (errno != EEXIST)
+            return -1;
+    }
+    errno = EEXIST;
+    return -1;
+}
+
+char *hax_mkdtemp(char *path_template)
+{
+    size_t length = path_template ? strlen(path_template) : 0;
+    if (length < 6 || strcmp(path_template + length - 6, "XXXXXX") != 0) {
+        errno = EINVAL;
+        return NULL;
+    }
+    static const char alphabet[] = "abcdefghijklmnopqrstuvwxyz0123456789";
+    for (int attempt = 0; attempt < 128; attempt++) {
+        unsigned char random[6];
+        if (fill_random(random, sizeof(random)) != 0) {
+            errno = EIO;
+            return NULL;
+        }
+        for (size_t i = 0; i < sizeof(random); i++)
+            path_template[length - 6 + i] = alphabet[random[i] % (sizeof(alphabet) - 1)];
+        if (hax_mkdir(path_template) == 0)
+            return path_template;
+        if (errno != EEXIST)
+            return NULL;
+    }
+    errno = EEXIST;
+    return NULL;
+}
+
+int hax_pread(int fd, void *buffer, size_t count, off_t offset)
+{
+    __int64 original = _telli64(fd);
+    if (original < 0 || _lseeki64(fd, offset, SEEK_SET) < 0)
+        return -1;
+    int result = _read(fd, buffer, count > INT_MAX ? INT_MAX : (unsigned int)count);
+    (void)_lseeki64(fd, original, SEEK_SET);
+    return result;
+}
+
+int flock(int fd, int operation)
+{
+    HANDLE handle = (HANDLE)_get_osfhandle(fd);
+    if (handle == INVALID_HANDLE_VALUE) {
+        errno = EBADF;
+        return -1;
+    }
+    /* Lock a sentinel byte beyond any valid session rather than the data range: Windows byte-range
+     * locks, unlike flock(2), also block writes through the locking handle. */
+    OVERLAPPED overlapped = {.Offset = UINT32_MAX};
+    if (operation & LOCK_UN) {
+        if (UnlockFileEx(handle, 0, 1, 0, &overlapped))
+            return 0;
+    } else {
+        DWORD flags = operation & LOCK_EX ? LOCKFILE_EXCLUSIVE_LOCK : 0;
+        if (operation & LOCK_NB)
+            flags |= LOCKFILE_FAIL_IMMEDIATELY;
+        if (LockFileEx(handle, flags, 0, 1, 0, &overlapped))
+            return 0;
+    }
+    set_errno_from_win32(GetLastError());
+    return -1;
+}
+
+struct hax_win32_dir {
+    HANDLE find;
+    WIN32_FIND_DATAW data;
+    int first;
+    struct dirent entry;
+};
+
+DIR *opendir(const char *path)
+{
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return NULL;
+    size_t length = wcslen(wide);
+    wchar_t *pattern = malloc((length + 3) * sizeof(*pattern));
+    if (!pattern) {
+        free(wide);
+        errno = ENOMEM;
+        return NULL;
+    }
+    wcscpy(pattern, wide);
+    if (length && pattern[length - 1] != L'\\')
+        pattern[length++] = L'\\';
+    pattern[length++] = L'*';
+    pattern[length] = L'\0';
+    free(wide);
+
+    DIR *directory = calloc(1, sizeof(*directory));
+    if (!directory) {
+        free(pattern);
+        errno = ENOMEM;
+        return NULL;
+    }
+    directory->find = FindFirstFileW(pattern, &directory->data);
+    free(pattern);
+    if (directory->find == INVALID_HANDLE_VALUE) {
+        set_errno_from_win32(GetLastError());
+        free(directory);
+        return NULL;
+    }
+    directory->first = 1;
+    return directory;
+}
+
+struct dirent *readdir(DIR *directory)
+{
+    if (!directory) {
+        errno = EBADF;
+        return NULL;
+    }
+    for (;;) {
+        if (directory->first)
+            directory->first = 0;
+        else if (!FindNextFileW(directory->find, &directory->data)) {
+            if (GetLastError() != ERROR_NO_MORE_FILES)
+                set_errno_from_win32(GetLastError());
+            return NULL;
+        }
+        char *name = wide_to_utf8(directory->data.cFileName);
+        if (!name)
+            return NULL;
+        size_t length = strlen(name);
+        if (length >= sizeof(directory->entry.d_name)) {
+            free(name);
+            errno = ENAMETOOLONG;
+            return NULL;
+        }
+        memcpy(directory->entry.d_name, name, length + 1);
+        free(name);
+        directory->entry.d_ino = 0;
+        DWORD attributes = directory->data.dwFileAttributes;
+        directory->entry.d_type = attributes & FILE_ATTRIBUTE_REPARSE_POINT ? DT_LNK
+                                  : attributes & FILE_ATTRIBUTE_DIRECTORY   ? DT_DIR
+                                                                            : DT_REG;
+        return &directory->entry;
+    }
+}
+
+int closedir(DIR *directory)
+{
+    if (!directory)
+        return -1;
+    FindClose(directory->find);
+    free(directory);
+    return 0;
+}
+
+int dirfd(DIR *directory)
+{
+    (void)directory;
+    errno = ENOTSUP;
+    return -1;
+}
+
+DIR *fdopendir(int fd)
+{
+    (void)fd;
+    errno = ENOTSUP;
+    return NULL;
+}
+
+char *basename(char *path)
+{
+    if (!path || !*path)
+        return ".";
+    char *last = path + strlen(path) - 1;
+    while (last > path && (*last == '/' || *last == '\\'))
+        *last-- = '\0';
+    char *slash = strrchr(path, '/');
+    char *backslash = strrchr(path, '\\');
+    char *separator = slash > backslash ? slash : backslash;
+    return separator ? separator + 1 : path;
+}
+
+char *dirname(char *path)
+{
+    if (!path || !*path)
+        return ".";
+    char *last = path + strlen(path) - 1;
+    while (last > path && (*last == '/' || *last == '\\'))
+        *last-- = '\0';
+    char *slash = strrchr(path, '/');
+    char *backslash = strrchr(path, '\\');
+    char *separator = slash > backslash ? slash : backslash;
+    if (!separator)
+        return ".";
+    if (separator == path) {
+        path[1] = '\0';
+        return path;
+    }
+    *separator = '\0';
+    return path;
+}
+
+static int glob_match(const char *pattern, const char *text)
+{
+    while (*pattern) {
+        if (*pattern == '*') {
+            while (*pattern == '*')
+                pattern++;
+            if (!*pattern)
+                return 1;
+            while (*text)
+                if (glob_match(pattern, text++))
+                    return 1;
+            return 0;
+        }
+        if (*pattern == '?') {
+            if (!*text)
+                return 0;
+            pattern++;
+            text++;
+            continue;
+        }
+        if (*pattern != *text)
+            return 0;
+        pattern++;
+        text++;
+    }
+    return *text == '\0';
+}
+
+int fnmatch(const char *pattern, const char *text, int flags)
+{
+    (void)flags;
+    return glob_match(pattern, text) ? 0 : 1;
+}
+
+char *optarg;
+int optind = 1;
+int opterr = 1;
+int optopt;
+
+int getopt_long(int argc, char *const argv[], const char *short_options,
+                const struct option *long_options, int *long_index)
+{
+    (void)short_options;
+    optarg = NULL;
+    if (optind >= argc)
+        return -1;
+    char *argument = argv[optind];
+    if (argument[0] != '-' || argument[1] == '\0')
+        return -1;
+    if (strcmp(argument, "--") == 0) {
+        optind++;
+        return -1;
+    }
+    if (argument[1] != '-') {
+        optind++;
+        if (argument[2] != '\0') {
+            optopt = argument[1];
+            return '?';
+        }
+        return (unsigned char)argument[1];
+    }
+
+    const char *name = argument + 2;
+    const char *equals = strchr(name, '=');
+    size_t name_length = equals ? (size_t)(equals - name) : strlen(name);
+    for (int i = 0; long_options[i].name; i++) {
+        if (strlen(long_options[i].name) != name_length ||
+            strncmp(long_options[i].name, name, name_length) != 0)
+            continue;
+        optind++;
+        if (long_index)
+            *long_index = i;
+        if (equals) {
+            if (long_options[i].has_arg == no_argument)
+                return '?';
+            optarg = (char *)equals + 1;
+        } else if (long_options[i].has_arg == required_argument) {
+            if (optind >= argc)
+                return '?';
+            optarg = argv[optind++];
+        }
+        if (long_options[i].flag) {
+            *long_options[i].flag = long_options[i].val;
+            return 0;
+        }
+        return long_options[i].val;
+    }
+    optind++;
+    return '?';
+}
+
+int tcgetattr(int fd, struct termios *attributes)
+{
+    HANDLE handle = (HANDLE)_get_osfhandle(fd);
+    DWORD mode;
+    if (handle == INVALID_HANDLE_VALUE) {
+        errno = ENOTTY;
+        return -1;
+    }
+    if (!GetConsoleMode(handle, &mode)) {
+        if (terminal_windows_stream_kind(fd) == TERMINAL_STREAM_MSYS_PTY) {
+            memset(attributes, 0, sizeof(*attributes));
+            attributes->c_lflag = ICANON | ECHO | ISIG;
+            return 0;
+        }
+        errno = ENOTTY;
+        return -1;
+    }
+    memset(attributes, 0, sizeof(*attributes));
+    attributes->input_mode = mode;
+    if (mode & ENABLE_LINE_INPUT)
+        attributes->c_lflag |= ICANON;
+    if (mode & ENABLE_ECHO_INPUT)
+        attributes->c_lflag |= ECHO;
+    if (mode & ENABLE_PROCESSED_INPUT)
+        attributes->c_lflag |= ISIG;
+    return 0;
+}
+
+int tcsetattr(int fd, int action, const struct termios *attributes)
+{
+    (void)action;
+    HANDLE handle = (HANDLE)_get_osfhandle(fd);
+    if (handle != INVALID_HANDLE_VALUE &&
+        terminal_windows_stream_kind(fd) == TERMINAL_STREAM_MSYS_PTY)
+        return 0;
+    DWORD mode = attributes->input_mode | ENABLE_VIRTUAL_TERMINAL_INPUT | ENABLE_EXTENDED_FLAGS;
+    mode &= ~ENABLE_QUICK_EDIT_MODE;
+    if (attributes->c_lflag & ICANON)
+        mode |= ENABLE_LINE_INPUT;
+    else
+        mode &= ~ENABLE_LINE_INPUT;
+    if (attributes->c_lflag & ECHO)
+        mode |= ENABLE_ECHO_INPUT;
+    else
+        mode &= ~ENABLE_ECHO_INPUT;
+    if (attributes->c_lflag & ISIG)
+        mode |= ENABLE_PROCESSED_INPUT;
+    else
+        mode &= ~ENABLE_PROCESSED_INPUT;
+    if (handle == INVALID_HANDLE_VALUE || !SetConsoleMode(handle, mode)) {
+        errno = ENOTTY;
+        return -1;
+    }
+    return 0;
+}
+
+int tcflush(int fd, int queue)
+{
+    (void)queue;
+    HANDLE handle = (HANDLE)_get_osfhandle(fd);
+    return handle != INVALID_HANDLE_VALUE && FlushConsoleInputBuffer(handle) ? 0 : -1;
+}
+
+int ioctl(int fd, int request, ...)
+{
+    if (request != TIOCGWINSZ) {
+        errno = EINVAL;
+        return -1;
+    }
+    va_list args;
+    va_start(args, request);
+    struct winsize *size = va_arg(args, struct winsize *);
+    va_end(args);
+    HANDLE handle = (HANDLE)_get_osfhandle(fd);
+    CONSOLE_SCREEN_BUFFER_INFO info;
+    if (handle == INVALID_HANDLE_VALUE || !GetConsoleScreenBufferInfo(handle, &info)) {
+        errno = ENOTTY;
+        return -1;
+    }
+    size->ws_col = (unsigned short)(info.srWindow.Right - info.srWindow.Left + 1);
+    size->ws_row = (unsigned short)(info.srWindow.Bottom - info.srWindow.Top + 1);
+    return 0;
+}
+
+int poll(struct pollfd *fds, nfds_t count, int timeout_ms)
+{
+    if (!fds || count == 0) {
+        if (timeout_ms > 0)
+            Sleep((DWORD)timeout_ms);
+        return 0;
+    }
+    DWORD started = GetTickCount();
+    for (;;) {
+        int ready = 0;
+        for (nfds_t i = 0; i < count; i++) {
+            fds[i].revents = 0;
+            HANDLE handle = (HANDLE)_get_osfhandle(fds[i].fd);
+            if (handle == INVALID_HANDLE_VALUE) {
+                fds[i].revents = POLLNVAL;
+            } else if (fds[i].events & POLLIN) {
+                DWORD type = GetFileType(handle);
+                if (type == FILE_TYPE_PIPE) {
+                    DWORD available = 0;
+                    if (!PeekNamedPipe(handle, NULL, 0, NULL, &available, NULL))
+                        fds[i].revents = POLLHUP;
+                    else if (available)
+                        fds[i].revents = POLLIN;
+                } else if (WaitForSingleObject(handle, 0) == WAIT_OBJECT_0) {
+                    fds[i].revents = POLLIN;
+                }
+            } else if (fds[i].events & POLLOUT) {
+                fds[i].revents = POLLOUT;
+            }
+            ready += fds[i].revents != 0;
+        }
+        if (ready || timeout_ms == 0)
+            return ready;
+        if (timeout_ms > 0 && GetTickCount() - started >= (DWORD)timeout_ms)
+            return 0;
+        Sleep(1);
+    }
+}
+
+int hax_kill(pid_t pid, int signal_number)
+{
+    if (pid < 0)
+        pid = -pid;
+    HANDLE process = OpenProcess(PROCESS_TERMINATE, FALSE, (DWORD)pid);
+    if (!process) {
+        set_errno_from_win32(GetLastError());
+        return -1;
+    }
+    BOOL terminated = TerminateProcess(process, signal_number ? 128 + signal_number : 1);
+    if (!terminated)
+        set_errno_from_win32(GetLastError());
+    CloseHandle(process);
+    return terminated ? 0 : -1;
+}
+
+pid_t spawn_win32_waitpid(pid_t pid, int *status, int options);
+
+pid_t waitpid(pid_t pid, int *status, int options)
+{
+    pid_t registered = spawn_win32_waitpid(pid, status, options);
+    if (registered >= 0 || errno != ECHILD)
+        return registered;
+    HANDLE process =
+        OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, FALSE, (DWORD)pid);
+    if (!process) {
+        errno = ECHILD;
+        return -1;
+    }
+    DWORD wait = WaitForSingleObject(process, options & WNOHANG ? 0 : INFINITE);
+    if (wait == WAIT_TIMEOUT) {
+        CloseHandle(process);
+        return 0;
+    }
+    DWORD exit_code = 1;
+    GetExitCodeProcess(process, &exit_code);
+    CloseHandle(process);
+    if (status)
+        *status = exit_code < 256 ? (int)exit_code : 1;
+    return pid;
+}
+
+int uname(struct utsname *name)
+{
+    if (!name) {
+        errno = EINVAL;
+        return -1;
+    }
+    memset(name, 0, sizeof(*name));
+    strcpy(name->sysname, "Windows");
+#if defined(_M_X64)
+    strcpy(name->machine, "x86_64");
+#elif defined(_M_ARM64)
+    strcpy(name->machine, "arm64");
+#else
+    strcpy(name->machine, "unknown");
+#endif
+    typedef LONG(WINAPI * rtl_get_version_fn)(OSVERSIONINFOW *);
+    HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
+    rtl_get_version_fn get_version =
+        ntdll ? (rtl_get_version_fn)GetProcAddress(ntdll, "RtlGetVersion") : NULL;
+    OSVERSIONINFOW version = {.dwOSVersionInfoSize = sizeof(version)};
+    if (get_version && get_version(&version) == 0)
+        snprintf(name->release, sizeof(name->release), "%lu.%lu.%lu", version.dwMajorVersion,
+                 version.dwMinorVersion, version.dwBuildNumber);
+    else
+        strcpy(name->release, "10+");
+    return 0;
+}
+
+#else
+
+typedef int hax_win32_empty_translation_unit;
+
+#endif /* _WIN32 */

--- a/src/system/win32.c
+++ b/src/system/win32.c
@@ -1,15 +1,15 @@
 /* SPDX-License-Identifier: MIT */
 #ifdef _WIN32
 
-#include "hax_win32.h"
+#include "system/win32_include/hax_win32.h"
 
 #undef access
 #undef chdir
 #undef chmod
+#undef fchmod
 #undef getcwd
 #undef getline
 #undef gmtime_r
-#undef kill
 #undef lstat
 #undef localtime_r
 #undef readlink
@@ -34,6 +34,7 @@
 #undef utimensat
 #undef wcwidth
 
+#include <aclapi.h>
 #include <bcrypt.h>
 #include <direct.h>
 #include <dirent.h>
@@ -606,9 +607,15 @@ static FILETIME timespec_to_filetime(const struct timespec *time_value)
 
 int futimens(int fd, const struct timespec times[2])
 {
-    HANDLE handle = (HANDLE)_get_osfhandle(fd);
-    if (handle == INVALID_HANDLE_VALUE) {
+    HANDLE source = (HANDLE)_get_osfhandle(fd);
+    if (source == INVALID_HANDLE_VALUE) {
         errno = EBADF;
+        return -1;
+    }
+    HANDLE handle = ReOpenFile(source, FILE_WRITE_ATTRIBUTES,
+                               FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, 0);
+    if (handle == INVALID_HANDLE_VALUE) {
+        set_errno_from_win32(GetLastError());
         return -1;
     }
     FILETIME access_time;
@@ -630,11 +637,13 @@ int futimens(int fd, const struct timespec times[2])
             write_ptr = &write_time;
         }
     }
-    if (!SetFileTime(handle, NULL, access_ptr, write_ptr)) {
-        set_errno_from_win32(GetLastError());
-        return -1;
-    }
-    return 0;
+    BOOL updated = SetFileTime(handle, NULL, access_ptr, write_ptr);
+    DWORD error = updated ? ERROR_SUCCESS : GetLastError();
+    CloseHandle(handle);
+    if (updated)
+        return 0;
+    set_errno_from_win32(error);
+    return -1;
 }
 
 int hax_utimensat(int directory_fd, const char *path, const struct timespec times[2], int flags)
@@ -659,12 +668,9 @@ int hax_pipe(int fds[2])
 
 int hax_fcntl(int fd, int command, ...)
 {
-    if (command == F_GETFL)
-        return 0;
-    if (command == F_SETFD || command == F_SETFL)
-        return 0;
     (void)fd;
-    errno = EINVAL;
+    (void)command;
+    errno = ENOTSUP;
     return -1;
 }
 
@@ -689,26 +695,163 @@ int hax_wcwidth(wchar_t codepoint)
     return 1;
 }
 
+static int restrict_handle_to_owner(HANDLE handle, int inherit)
+{
+    PSID owner = NULL;
+    PSECURITY_DESCRIPTOR descriptor = NULL;
+    DWORD result = GetSecurityInfo(handle, SE_FILE_OBJECT, OWNER_SECURITY_INFORMATION, &owner, NULL,
+                                   NULL, NULL, &descriptor);
+    if (result != ERROR_SUCCESS) {
+        set_errno_from_win32(result);
+        return -1;
+    }
+
+    EXPLICIT_ACCESSW access = {0};
+    access.grfAccessPermissions = GENERIC_ALL;
+    access.grfAccessMode = SET_ACCESS;
+    access.grfInheritance = inherit ? SUB_CONTAINERS_AND_OBJECTS_INHERIT : NO_INHERITANCE;
+    access.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+    access.Trustee.TrusteeType = TRUSTEE_IS_USER;
+    access.Trustee.ptstrName = owner;
+    PACL acl = NULL;
+    result = SetEntriesInAclW(1, &access, NULL, &acl);
+    if (result == ERROR_SUCCESS)
+        result = SetSecurityInfo(handle, SE_FILE_OBJECT,
+                                 DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+                                 NULL, NULL, acl, NULL);
+    LocalFree(acl);
+    LocalFree(descriptor);
+    if (result == ERROR_SUCCESS)
+        return 0;
+    set_errno_from_win32(result);
+    return -1;
+}
+
+int hax_fchmod(int fd, mode_t mode)
+{
+    if (mode != 0600 && mode != 0700) {
+        errno = ENOTSUP;
+        return -1;
+    }
+    HANDLE handle = (HANDLE)_get_osfhandle(fd);
+    if (handle == INVALID_HANDLE_VALUE) {
+        errno = EBADF;
+        return -1;
+    }
+    BY_HANDLE_FILE_INFORMATION info;
+    if (!GetFileInformationByHandle(handle, &info)) {
+        set_errno_from_win32(GetLastError());
+        return -1;
+    }
+    return restrict_handle_to_owner(handle, info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+static DWORD open_access(int flags)
+{
+    int access_mode = flags & (_O_RDONLY | _O_WRONLY | _O_RDWR);
+    DWORD access = access_mode == _O_WRONLY ? GENERIC_WRITE
+                   : access_mode == _O_RDWR ? GENERIC_READ | GENERIC_WRITE
+                                            : GENERIC_READ;
+    if (flags & O_APPEND) {
+        access &= ~GENERIC_WRITE;
+        access |= FILE_APPEND_DATA;
+    }
+    return access;
+}
+
+static DWORD open_creation(int flags)
+{
+    if (flags & O_CREAT)
+        return flags & O_EXCL ? CREATE_NEW : flags & O_TRUNC ? CREATE_ALWAYS : OPEN_ALWAYS;
+    return flags & O_TRUNC ? TRUNCATE_EXISTING : OPEN_EXISTING;
+}
+
 int hax_open(const char *path, int flags, ...)
 {
-    int mode = _S_IREAD | _S_IWRITE;
+    int mode = 0666;
     if (flags & O_CREAT) {
         va_list args;
         va_start(args, flags);
         mode = va_arg(args, int);
         va_end(args);
     }
+    if ((flags & O_CREAT) && !(mode & 0077) && mode != 0600 && mode != 0700) {
+        errno = ENOTSUP;
+        return -1;
+    }
     wchar_t *wide = path_to_wide(path);
     if (!wide)
         return -1;
-    int fd = _wopen(wide, flags | _O_BINARY | _O_NOINHERIT, mode);
+
+    DWORD attributes = flags & O_DIRECTORY ? FILE_FLAG_BACKUP_SEMANTICS : FILE_ATTRIBUTE_NORMAL;
+    if (flags & O_NOFOLLOW)
+        attributes |= FILE_FLAG_OPEN_REPARSE_POINT;
+    DWORD desired_access = open_access(flags);
+    if ((flags & O_CREAT) && !(mode & 0077))
+        desired_access |= READ_CONTROL | WRITE_DAC;
+    HANDLE handle =
+        CreateFileW(wide, desired_access, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    NULL, open_creation(flags), attributes, NULL);
     free(wide);
+    if (handle == INVALID_HANDLE_VALUE) {
+        set_errno_from_win32(GetLastError());
+        return -1;
+    }
+
+    FILE_ATTRIBUTE_TAG_INFO info;
+    if (!GetFileInformationByHandleEx(handle, FileAttributeTagInfo, &info, sizeof(info))) {
+        set_errno_from_win32(GetLastError());
+        CloseHandle(handle);
+        return -1;
+    }
+    if ((flags & O_NOFOLLOW) && (info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)) {
+        CloseHandle(handle);
+        errno = ELOOP;
+        return -1;
+    }
+    if ((flags & O_DIRECTORY) && !(info.FileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+        CloseHandle(handle);
+        errno = ENOTDIR;
+        return -1;
+    }
+    if ((flags & O_NONBLOCK) && GetFileType(handle) != FILE_TYPE_DISK) {
+        CloseHandle(handle);
+        errno = ENOTSUP;
+        return -1;
+    }
+    if ((flags & O_CREAT) && !(mode & 0077) && restrict_handle_to_owner(handle, 0) < 0) {
+        CloseHandle(handle);
+        return -1;
+    }
+
+    int crt_flags = flags & (_O_RDONLY | _O_WRONLY | _O_RDWR | _O_APPEND);
+    int fd = _open_osfhandle((intptr_t)handle, crt_flags | _O_BINARY | _O_NOINHERIT);
+    if (fd < 0)
+        CloseHandle(handle);
     return fd;
 }
 
 static char *binary_mode(const char *mode)
 {
-    return strchr(mode, 'b') ? _strdup(mode) : xasprintf("%sb", mode);
+    size_t length = strlen(mode);
+    char *binary = xmalloc(length + 2);
+    size_t out = 0;
+    int has_binary = 0;
+    size_t comma = length;
+    for (size_t i = 0; i < length; i++) {
+        if (mode[i] == ',') {
+            comma = i;
+            break;
+        }
+        if (mode[i] == 'e')
+            continue;
+        has_binary |= mode[i] == 'b';
+        binary[out++] = mode[i];
+    }
+    if (!has_binary)
+        binary[out++] = 'b';
+    memcpy(binary + out, mode + comma, length - comma + 1);
+    return binary;
 }
 
 FILE *hax_fopen(const char *path, const char *mode)
@@ -853,8 +996,31 @@ int hax_chdir(const char *path)
 
 int hax_chmod(const char *path, int mode)
 {
-    (void)mode;
-    return hax_access(path, F_OK);
+    if (mode != 0600 && mode != 0700) {
+        errno = ENOTSUP;
+        return -1;
+    }
+    wchar_t *wide = path_to_wide(path);
+    if (!wide)
+        return -1;
+    HANDLE handle = CreateFileW(wide, READ_CONTROL | WRITE_DAC,
+                                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL,
+                                OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+    free(wide);
+    if (handle == INVALID_HANDLE_VALUE) {
+        set_errno_from_win32(GetLastError());
+        return -1;
+    }
+    BY_HANDLE_FILE_INFORMATION info;
+    int result;
+    if (!GetFileInformationByHandle(handle, &info)) {
+        set_errno_from_win32(GetLastError());
+        result = -1;
+    } else {
+        result = restrict_handle_to_owner(handle, info.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY);
+    }
+    CloseHandle(handle);
+    return result;
 }
 
 char *hax_getcwd(char *buffer, int size)
@@ -1135,14 +1301,41 @@ char *hax_mkdtemp(char *path_template)
     return NULL;
 }
 
-int hax_pread(int fd, void *buffer, size_t count, off_t offset)
+ssize_t hax_pread(int fd, void *buffer, size_t count, off_t offset)
 {
-    __int64 original = _telli64(fd);
-    if (original < 0 || _lseeki64(fd, offset, SEEK_SET) < 0)
+    if (offset < 0) {
+        errno = EINVAL;
         return -1;
-    int result = _read(fd, buffer, count > INT_MAX ? INT_MAX : (unsigned int)count);
-    (void)_lseeki64(fd, original, SEEK_SET);
-    return result;
+    }
+    HANDLE source = (HANDLE)_get_osfhandle(fd);
+    if (source == INVALID_HANDLE_VALUE) {
+        errno = EBADF;
+        return -1;
+    }
+    HANDLE handle =
+        ReOpenFile(source, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                   FILE_FLAG_OVERLAPPED);
+    if (handle == INVALID_HANDLE_VALUE) {
+        set_errno_from_win32(GetLastError());
+        return -1;
+    }
+
+    OVERLAPPED operation = {0};
+    operation.Offset = (DWORD)((uint64_t)offset & UINT32_MAX);
+    operation.OffsetHigh = (DWORD)((uint64_t)offset >> 32);
+    DWORD bytes_read = 0;
+    DWORD requested = count > UINT32_MAX ? UINT32_MAX : (DWORD)count;
+    BOOL completed = ReadFile(handle, buffer, requested, &bytes_read, &operation);
+    if (!completed && GetLastError() == ERROR_IO_PENDING)
+        completed = GetOverlappedResult(handle, &operation, &bytes_read, TRUE);
+    DWORD error = completed ? ERROR_SUCCESS : GetLastError();
+    CloseHandle(handle);
+    if (completed)
+        return (ssize_t)bytes_read;
+    if (error == ERROR_HANDLE_EOF)
+        return 0;
+    set_errno_from_win32(error);
+    return -1;
 }
 
 int flock(int fd, int operation)
@@ -1485,9 +1678,8 @@ static int console_input_ready(HANDLE handle)
             return 0;
         if (record.EventType == KEY_EVENT && record.Event.KeyEvent.bKeyDown) {
             WORD key = record.Event.KeyEvent.wVirtualKeyCode;
-            if (record.Event.KeyEvent.uChar.UnicodeChar != L'\0' && key != VK_SHIFT &&
-                key != VK_CONTROL && key != VK_MENU && key != VK_CAPITAL && key != VK_NUMLOCK &&
-                key != VK_SCROLL)
+            if (key != VK_SHIFT && key != VK_CONTROL && key != VK_MENU && key != VK_CAPITAL &&
+                key != VK_NUMLOCK && key != VK_SCROLL)
                 return 1;
         }
         if (!ReadConsoleInputW(handle, &record, 1, &count))
@@ -1539,48 +1731,6 @@ int poll(struct pollfd *fds, nfds_t count, int timeout_ms)
             return 0;
         Sleep(1);
     }
-}
-
-int hax_kill(pid_t pid, int signal_number)
-{
-    if (pid < 0)
-        pid = -pid;
-    HANDLE process = OpenProcess(PROCESS_TERMINATE, FALSE, (DWORD)pid);
-    if (!process) {
-        set_errno_from_win32(GetLastError());
-        return -1;
-    }
-    BOOL terminated = TerminateProcess(process, signal_number ? 128 + signal_number : 1);
-    if (!terminated)
-        set_errno_from_win32(GetLastError());
-    CloseHandle(process);
-    return terminated ? 0 : -1;
-}
-
-pid_t spawn_win32_waitpid(pid_t pid, int *status, int options);
-
-pid_t waitpid(pid_t pid, int *status, int options)
-{
-    pid_t registered = spawn_win32_waitpid(pid, status, options);
-    if (registered >= 0 || errno != ECHILD)
-        return registered;
-    HANDLE process =
-        OpenProcess(SYNCHRONIZE | PROCESS_QUERY_LIMITED_INFORMATION, FALSE, (DWORD)pid);
-    if (!process) {
-        errno = ECHILD;
-        return -1;
-    }
-    DWORD wait = WaitForSingleObject(process, options & WNOHANG ? 0 : INFINITE);
-    if (wait == WAIT_TIMEOUT) {
-        CloseHandle(process);
-        return 0;
-    }
-    DWORD exit_code = 1;
-    GetExitCodeProcess(process, &exit_code);
-    CloseHandle(process);
-    if (status)
-        *status = exit_code < 256 ? (int)exit_code : 1;
-    return pid;
 }
 
 int uname(struct utsname *name)

--- a/src/system/win32_include/dirent.h
+++ b/src/system/win32_include/dirent.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_DIRENT_H
-#define HAX_WIN32_DIRENT_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_DIRENT_H
+#define HAX_SYSTEM_WIN32_INCLUDE_DIRENT_H
 
 #include <stdint.h>
 #include <windows.h>
@@ -23,4 +23,4 @@ int closedir(DIR *directory);
 int dirfd(DIR *directory);
 DIR *fdopendir(int fd);
 
-#endif /* HAX_WIN32_DIRENT_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_DIRENT_H */

--- a/src/system/win32_include/dirent.h
+++ b/src/system/win32_include/dirent.h
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_DIRENT_H
+#define HAX_WIN32_DIRENT_H
+
+#include <stdint.h>
+#include <windows.h>
+
+#define DT_UNKNOWN 0
+#define DT_DIR     4
+#define DT_REG     8
+#define DT_LNK     10
+
+struct dirent {
+    uint64_t d_ino;
+    unsigned char d_type;
+    char d_name[1024];
+};
+
+typedef struct hax_win32_dir DIR;
+DIR *opendir(const char *path);
+struct dirent *readdir(DIR *directory);
+int closedir(DIR *directory);
+int dirfd(DIR *directory);
+DIR *fdopendir(int fd);
+
+#endif /* HAX_WIN32_DIRENT_H */

--- a/src/system/win32_include/fnmatch.h
+++ b/src/system/win32_include/fnmatch.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_FNMATCH_H
+#define HAX_WIN32_FNMATCH_H
+
+#define FNM_NOMATCH 1
+int fnmatch(const char *pattern, const char *text, int flags);
+
+#endif /* HAX_WIN32_FNMATCH_H */

--- a/src/system/win32_include/fnmatch.h
+++ b/src/system/win32_include/fnmatch.h
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_FNMATCH_H
-#define HAX_WIN32_FNMATCH_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_FNMATCH_H
+#define HAX_SYSTEM_WIN32_INCLUDE_FNMATCH_H
 
 #define FNM_NOMATCH 1
 int fnmatch(const char *pattern, const char *text, int flags);
 
-#endif /* HAX_WIN32_FNMATCH_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_FNMATCH_H */

--- a/src/system/win32_include/getopt.h
+++ b/src/system/win32_include/getopt.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_GETOPT_H
+#define HAX_WIN32_GETOPT_H
+
+#define no_argument       0
+#define required_argument 1
+#define optional_argument 2
+
+struct option {
+    const char *name;
+    int has_arg;
+    int *flag;
+    int val;
+};
+
+extern char *optarg;
+extern int optind;
+extern int opterr;
+extern int optopt;
+
+int getopt_long(int argc, char *const argv[], const char *short_options,
+                const struct option *long_options, int *long_index);
+
+#endif /* HAX_WIN32_GETOPT_H */

--- a/src/system/win32_include/getopt.h
+++ b/src/system/win32_include/getopt.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_GETOPT_H
-#define HAX_WIN32_GETOPT_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_GETOPT_H
+#define HAX_SYSTEM_WIN32_INCLUDE_GETOPT_H
 
 #define no_argument       0
 #define required_argument 1
@@ -21,4 +21,4 @@ extern int optopt;
 int getopt_long(int argc, char *const argv[], const char *short_options,
                 const struct option *long_options, int *long_index);
 
-#endif /* HAX_WIN32_GETOPT_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_GETOPT_H */

--- a/src/system/win32_include/hax_win32.h
+++ b/src/system/win32_include/hax_win32.h
@@ -160,6 +160,7 @@ int hax_wcwidth(wchar_t codepoint);
 
 void win32_process_init(int *argc, char ***argv);
 void win32_terminal_acquire(void);
+void win32_terminal_leave_for_child(void);
 void win32_terminal_release(void);
 
 int hax_open(const char *path, int flags, ...);

--- a/src/system/win32_include/hax_win32.h
+++ b/src/system/win32_include/hax_win32.h
@@ -1,0 +1,228 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_COMPAT_H
+#define HAX_WIN32_COMPAT_H
+
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0a00
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#if defined(_MSC_VER) && !defined(__clang__)
+#define __attribute__(attributes)
+#endif
+
+/* bcrypt.h relies on the Win32 base types and annotations. */
+#include <windows.h>
+#if defined(_WIN32)
+#include <bcrypt.h>
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <sys/stat.h>
+
+#include "unistd.h"
+
+#ifndef PATH_MAX
+#define PATH_MAX 32768
+#endif
+#ifndef NAME_MAX
+#define NAME_MAX 255
+#endif
+#ifndef S_ISREG
+#define S_ISREG(mode) (((mode) & _S_IFMT) == _S_IFREG)
+#define S_ISDIR(mode) (((mode) & _S_IFMT) == _S_IFDIR)
+#endif
+#ifndef S_IFLNK
+#define S_IFLNK 0120000
+#endif
+#ifndef S_ISLNK
+#define S_ISLNK(mode) (((mode) & S_IFLNK) == S_IFLNK)
+#endif
+#ifndef CLOCK_REALTIME
+#define CLOCK_REALTIME  0
+#define CLOCK_MONOTONIC 1
+#endif
+#ifndef SIGQUIT
+#define SIGQUIT 3
+#endif
+#ifndef SIGHUP
+#define SIGHUP 1
+#endif
+#ifndef SIGPIPE
+#define SIGPIPE 13
+#endif
+#ifndef SIGCHLD
+#define SIGCHLD 17
+#endif
+#ifndef SIGTSTP
+#define SIGTSTP 20
+#endif
+#ifndef SIGKILL
+#define SIGKILL 9
+#endif
+#ifndef SIG_BLOCK
+#define SIG_BLOCK   0
+#define SIG_SETMASK 1
+#endif
+#ifndef SA_RESTART
+#define SA_RESTART 0
+#endif
+#ifndef UTIME_OMIT
+#define UTIME_OMIT ((long)1073741822L)
+#define AT_FDCWD   (-100)
+#endif
+
+#define strdup                     _strdup
+#define strcasecmp                 _stricmp
+#define strncasecmp                _strnicmp
+#define strtok_r(str, delim, save) strtok_s((str), (delim), (save))
+
+struct sigaction {
+    void (*sa_handler)(int);
+    int sa_flags;
+    unsigned long sa_mask;
+};
+typedef unsigned long sigset_t;
+
+static inline int sigemptyset(sigset_t *set)
+{
+    *set = 0;
+    return 0;
+}
+
+static inline int sigfillset(sigset_t *set)
+{
+    *set = ~0UL;
+    return 0;
+}
+
+static inline int sigaddset(sigset_t *set, int signal_number)
+{
+    if (signal_number >= 0 && signal_number < 32)
+        *set |= 1UL << signal_number;
+    return 0;
+}
+
+static inline int hax_signal_supported(int signal_number)
+{
+    return signal_number == SIGABRT || signal_number == SIGFPE || signal_number == SIGILL ||
+           signal_number == SIGINT || signal_number == SIGSEGV || signal_number == SIGTERM;
+}
+
+static inline int sigaction(int signal_number, const struct sigaction *action,
+                            struct sigaction *old_action)
+{
+    void (*previous)(int) = SIG_DFL;
+    if (hax_signal_supported(signal_number)) {
+        previous = signal(signal_number, action ? action->sa_handler : SIG_DFL);
+        if (previous == SIG_ERR)
+            return -1;
+    }
+    if (old_action) {
+        memset(old_action, 0, sizeof(*old_action));
+        old_action->sa_handler = previous;
+    }
+    return 0;
+}
+
+static inline int hax_raise(int signal_number)
+{
+    return hax_signal_supported(signal_number) ? raise(signal_number) : 0;
+}
+
+static inline int sigprocmask(int how, const sigset_t *set, sigset_t *old_set)
+{
+    (void)how;
+    (void)set;
+    if (old_set)
+        *old_set = 0;
+    return 0;
+}
+
+int clock_gettime(int clock_id, struct timespec *time_value);
+int nanosleep(const struct timespec *request, struct timespec *remaining);
+int hax_kill(pid_t pid, int signal_number);
+ssize_t hax_getline(char **line, size_t *capacity, FILE *stream);
+struct tm *hax_gmtime_r(const time_t *time_value, struct tm *result);
+struct tm *hax_localtime_r(const time_t *time_value, struct tm *result);
+ssize_t hax_readlink(const char *path, char *buffer, size_t capacity);
+int futimens(int fd, const struct timespec times[2]);
+int hax_pipe(int fds[2]);
+int hax_fcntl(int fd, int command, ...);
+int hax_wcwidth(wchar_t codepoint);
+
+void win32_process_init(int *argc, char ***argv);
+void win32_terminal_acquire(void);
+void win32_terminal_release(void);
+
+int hax_open(const char *path, int flags, ...);
+FILE *hax_fopen(const char *path, const char *mode);
+FILE *hax_freopen(const char *path, const char *mode, FILE *stream);
+FILE *hax_open_memstream(char **buffer, size_t *length);
+int hax_fclose(FILE *stream);
+int hax_fflush(FILE *stream);
+int hax_access(const char *path, int mode);
+int hax_chdir(const char *path);
+int hax_chmod(const char *path, int mode);
+char *hax_getcwd(char *buffer, int size);
+int hax_mkdir(const char *path);
+int hax_rename(const char *old_path, const char *new_path);
+int hax_remove(const char *path);
+int hax_rmdir(const char *path);
+int hax_stat(const char *path, struct stat *status);
+int hax_lstat(const char *path, struct stat *status);
+int hax_unlink(const char *path);
+int hax_symlink(const char *target, const char *link_path);
+int hax_utimensat(int directory_fd, const char *path, const struct timespec times[2], int flags);
+char *hax_realpath(const char *path, char *resolved);
+char *hax_search_path(const char *name);
+int hax_mkstemp(char *path_template);
+char *hax_mkdtemp(char *path_template);
+
+#define open                hax_open
+#define fopen               hax_fopen
+#define freopen             hax_freopen
+#define open_memstream      hax_open_memstream
+#define fclose              hax_fclose
+#define fflush              hax_fflush
+#define access              hax_access
+#define chdir               hax_chdir
+#define chmod               hax_chmod
+#define getcwd              hax_getcwd
+#define kill                hax_kill
+#define raise               hax_raise
+#define getline             hax_getline
+#define gmtime_r            hax_gmtime_r
+#define localtime_r         hax_localtime_r
+#define readlink            hax_readlink
+#define pipe                hax_pipe
+#define fcntl               hax_fcntl
+#define wcwidth             hax_wcwidth
+#define lstat(path, status) hax_lstat((path), (status))
+#define mkdir(path, mode)   hax_mkdir(path)
+#define mkdtemp             hax_mkdtemp
+#define mkstemp             hax_mkstemp
+#define realpath            hax_realpath
+#define remove              hax_remove
+#define rename              hax_rename
+#define rmdir               hax_rmdir
+#define stat(path, status)  hax_stat((path), (status))
+#define unlink              hax_unlink
+#define symlink             hax_symlink
+#define utimensat           hax_utimensat
+
+#ifndef F_SETFD
+#define F_SETFD    1
+#define F_GETFL    2
+#define F_SETFL    3
+#define FD_CLOEXEC 1
+#endif
+
+#endif /* HAX_WIN32_COMPAT_H */

--- a/src/system/win32_include/hax_win32.h
+++ b/src/system/win32_include/hax_win32.h
@@ -1,10 +1,7 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_COMPAT_H
-#define HAX_WIN32_COMPAT_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_HAX_WIN32_H
+#define HAX_SYSTEM_WIN32_INCLUDE_HAX_WIN32_H
 
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0a00
-#endif
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -27,7 +24,7 @@
 #include <time.h>
 #include <sys/stat.h>
 
-#include "unistd.h"
+#include "system/win32_include/unistd.h"
 
 #ifndef PATH_MAX
 #define PATH_MAX 32768
@@ -148,7 +145,6 @@ static inline int sigprocmask(int how, const sigset_t *set, sigset_t *old_set)
 
 int clock_gettime(int clock_id, struct timespec *time_value);
 int nanosleep(const struct timespec *request, struct timespec *remaining);
-int hax_kill(pid_t pid, int signal_number);
 ssize_t hax_getline(char **line, size_t *capacity, FILE *stream);
 struct tm *hax_gmtime_r(const time_t *time_value, struct tm *result);
 struct tm *hax_localtime_r(const time_t *time_value, struct tm *result);
@@ -197,7 +193,6 @@ char *hax_mkdtemp(char *path_template);
 #define chdir               hax_chdir
 #define chmod               hax_chmod
 #define getcwd              hax_getcwd
-#define kill                hax_kill
 #define raise               hax_raise
 #define getline             hax_getline
 #define gmtime_r            hax_gmtime_r
@@ -226,4 +221,4 @@ char *hax_mkdtemp(char *path_template);
 #define FD_CLOEXEC 1
 #endif
 
-#endif /* HAX_WIN32_COMPAT_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_HAX_WIN32_H */

--- a/src/system/win32_include/langinfo.h
+++ b/src/system/win32_include/langinfo.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_LANGINFO_H
-#define HAX_WIN32_LANGINFO_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_LANGINFO_H
+#define HAX_SYSTEM_WIN32_INCLUDE_LANGINFO_H
 
 #define CODESET 0
 static inline const char *nl_langinfo(int item)
@@ -9,4 +9,4 @@ static inline const char *nl_langinfo(int item)
     return "UTF-8";
 }
 
-#endif /* HAX_WIN32_LANGINFO_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_LANGINFO_H */

--- a/src/system/win32_include/langinfo.h
+++ b/src/system/win32_include/langinfo.h
@@ -1,0 +1,12 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_LANGINFO_H
+#define HAX_WIN32_LANGINFO_H
+
+#define CODESET 0
+static inline const char *nl_langinfo(int item)
+{
+    (void)item;
+    return "UTF-8";
+}
+
+#endif /* HAX_WIN32_LANGINFO_H */

--- a/src/system/win32_include/libgen.h
+++ b/src/system/win32_include/libgen.h
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_LIBGEN_H
-#define HAX_WIN32_LIBGEN_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_LIBGEN_H
+#define HAX_SYSTEM_WIN32_INCLUDE_LIBGEN_H
 
 char *basename(char *path);
 char *dirname(char *path);
 
-#endif /* HAX_WIN32_LIBGEN_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_LIBGEN_H */

--- a/src/system/win32_include/libgen.h
+++ b/src/system/win32_include/libgen.h
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_LIBGEN_H
+#define HAX_WIN32_LIBGEN_H
+
+char *basename(char *path);
+char *dirname(char *path);
+
+#endif /* HAX_WIN32_LIBGEN_H */

--- a/src/system/win32_include/poll.h
+++ b/src/system/win32_include/poll.h
@@ -1,0 +1,22 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_POLL_H
+#define HAX_WIN32_POLL_H
+
+#include <windows.h>
+
+#define POLLIN   0x0001
+#define POLLOUT  0x0004
+#define POLLERR  0x0008
+#define POLLHUP  0x0010
+#define POLLNVAL 0x0020
+
+struct pollfd {
+    int fd;
+    short events;
+    short revents;
+};
+
+typedef unsigned long nfds_t;
+int poll(struct pollfd *fds, nfds_t count, int timeout_ms);
+
+#endif /* HAX_WIN32_POLL_H */

--- a/src/system/win32_include/poll.h
+++ b/src/system/win32_include/poll.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_POLL_H
-#define HAX_WIN32_POLL_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_POLL_H
+#define HAX_SYSTEM_WIN32_INCLUDE_POLL_H
 
 #include <windows.h>
 
@@ -19,4 +19,4 @@ struct pollfd {
 typedef unsigned long nfds_t;
 int poll(struct pollfd *fds, nfds_t count, int timeout_ms);
 
-#endif /* HAX_WIN32_POLL_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_POLL_H */

--- a/src/system/win32_include/pthread.h
+++ b/src/system/win32_include/pthread.h
@@ -1,0 +1,138 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_PTHREAD_H
+#define HAX_WIN32_PTHREAD_H
+
+#include <errno.h>
+#include <process.h>
+#include <stdlib.h>
+#include <time.h>
+#include <windows.h>
+
+#define PTHREAD_MUTEX_INITIALIZER SRWLOCK_INIT
+#define SIG_BLOCK                 0
+#define SIG_SETMASK               1
+
+typedef HANDLE pthread_t;
+typedef SRWLOCK pthread_mutex_t;
+typedef CONDITION_VARIABLE pthread_cond_t;
+
+struct hax_thread_start {
+    void *(*fn)(void *);
+    void *arg;
+};
+
+static unsigned __stdcall hax_thread_trampoline(void *opaque)
+{
+    struct hax_thread_start *start = opaque;
+    void *(*fn)(void *) = start->fn;
+    void *arg = start->arg;
+    free(start);
+    fn(arg);
+    return 0;
+}
+
+static inline int pthread_create(pthread_t *thread, const void *attributes, void *(*fn)(void *),
+                                 void *arg)
+{
+    (void)attributes;
+    struct hax_thread_start *start = malloc(sizeof(*start));
+    if (!start)
+        return ENOMEM;
+    start->fn = fn;
+    start->arg = arg;
+    uintptr_t handle = _beginthreadex(NULL, 0, hax_thread_trampoline, start, 0, NULL);
+    if (!handle) {
+        free(start);
+        return errno ? errno : EAGAIN;
+    }
+    *thread = (HANDLE)handle;
+    return 0;
+}
+
+static inline int pthread_join(pthread_t thread, void **result)
+{
+    (void)result;
+    DWORD wait = WaitForSingleObject(thread, INFINITE);
+    CloseHandle(thread);
+    return wait == WAIT_OBJECT_0 ? 0 : EINVAL;
+}
+
+static inline int pthread_mutex_init(pthread_mutex_t *mutex, const void *attributes)
+{
+    (void)attributes;
+    InitializeSRWLock(mutex);
+    return 0;
+}
+
+static inline int pthread_mutex_destroy(pthread_mutex_t *mutex)
+{
+    (void)mutex;
+    return 0;
+}
+
+static inline int pthread_mutex_lock(pthread_mutex_t *mutex)
+{
+    AcquireSRWLockExclusive(mutex);
+    return 0;
+}
+
+static inline int pthread_mutex_unlock(pthread_mutex_t *mutex)
+{
+    ReleaseSRWLockExclusive(mutex);
+    return 0;
+}
+
+static inline int pthread_cond_init(pthread_cond_t *cond, const void *attributes)
+{
+    (void)attributes;
+    InitializeConditionVariable(cond);
+    return 0;
+}
+
+static inline int pthread_cond_destroy(pthread_cond_t *cond)
+{
+    (void)cond;
+    return 0;
+}
+
+static inline int pthread_cond_signal(pthread_cond_t *cond)
+{
+    WakeConditionVariable(cond);
+    return 0;
+}
+
+static inline int pthread_cond_broadcast(pthread_cond_t *cond)
+{
+    WakeAllConditionVariable(cond);
+    return 0;
+}
+
+static inline int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex)
+{
+    return SleepConditionVariableSRW(cond, mutex, INFINITE, 0) ? 0 : EINVAL;
+}
+
+static inline int pthread_cond_timedwait(pthread_cond_t *cond, pthread_mutex_t *mutex,
+                                         const struct timespec *deadline)
+{
+    struct timespec now;
+    timespec_get(&now, TIME_UTC);
+    int64_t remaining_ms = (int64_t)(deadline->tv_sec - now.tv_sec) * 1000 +
+                           (deadline->tv_nsec - now.tv_nsec + 999999) / 1000000;
+    DWORD timeout = remaining_ms <= 0           ? 0
+                    : remaining_ms > UINT32_MAX ? UINT32_MAX
+                                                : (DWORD)remaining_ms;
+    if (SleepConditionVariableSRW(cond, mutex, timeout, 0))
+        return 0;
+    return GetLastError() == ERROR_TIMEOUT ? ETIMEDOUT : EINVAL;
+}
+
+static inline int pthread_sigmask(int how, const void *set, void *old_set)
+{
+    (void)how;
+    (void)set;
+    (void)old_set;
+    return 0;
+}
+
+#endif /* HAX_WIN32_PTHREAD_H */

--- a/src/system/win32_include/pthread.h
+++ b/src/system/win32_include/pthread.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_PTHREAD_H
-#define HAX_WIN32_PTHREAD_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_PTHREAD_H
+#define HAX_SYSTEM_WIN32_INCLUDE_PTHREAD_H
 
 #include <errno.h>
 #include <process.h>
@@ -135,4 +135,4 @@ static inline int pthread_sigmask(int how, const void *set, void *old_set)
     return 0;
 }
 
-#endif /* HAX_WIN32_PTHREAD_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_PTHREAD_H */

--- a/src/system/win32_include/sched.h
+++ b/src/system/win32_include/sched.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_SCHED_H
+#define HAX_WIN32_SCHED_H
+
+#include <windows.h>
+
+static inline int sched_yield(void)
+{
+    Sleep(0);
+    return 0;
+}
+
+#endif /* HAX_WIN32_SCHED_H */

--- a/src/system/win32_include/sched.h
+++ b/src/system/win32_include/sched.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_SCHED_H
-#define HAX_WIN32_SCHED_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_SCHED_H
+#define HAX_SYSTEM_WIN32_INCLUDE_SCHED_H
 
 #include <windows.h>
 
@@ -10,4 +10,4 @@ static inline int sched_yield(void)
     return 0;
 }
 
-#endif /* HAX_WIN32_SCHED_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_SCHED_H */

--- a/src/system/win32_include/strings.h
+++ b/src/system/win32_include/strings.h
@@ -1,10 +1,10 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_STRINGS_H
-#define HAX_WIN32_STRINGS_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_STRINGS_H
+#define HAX_SYSTEM_WIN32_INCLUDE_STRINGS_H
 
 #include <string.h>
 
 #define strcasecmp  _stricmp
 #define strncasecmp _strnicmp
 
-#endif /* HAX_WIN32_STRINGS_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_STRINGS_H */

--- a/src/system/win32_include/strings.h
+++ b/src/system/win32_include/strings.h
@@ -1,0 +1,10 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_STRINGS_H
+#define HAX_WIN32_STRINGS_H
+
+#include <string.h>
+
+#define strcasecmp  _stricmp
+#define strncasecmp _strnicmp
+
+#endif /* HAX_WIN32_STRINGS_H */

--- a/src/system/win32_include/sys/file.h
+++ b/src/system/win32_include/sys/file.h
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_SYS_FILE_H
+#define HAX_WIN32_SYS_FILE_H
+
+#define LOCK_SH 1
+#define LOCK_EX 2
+#define LOCK_NB 4
+#define LOCK_UN 8
+int flock(int fd, int operation);
+
+#endif /* HAX_WIN32_SYS_FILE_H */

--- a/src/system/win32_include/sys/file.h
+++ b/src/system/win32_include/sys/file.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_SYS_FILE_H
-#define HAX_WIN32_SYS_FILE_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_SYS_FILE_H
+#define HAX_SYSTEM_WIN32_INCLUDE_SYS_FILE_H
 
 #define LOCK_SH 1
 #define LOCK_EX 2
@@ -8,4 +8,4 @@
 #define LOCK_UN 8
 int flock(int fd, int operation);
 
-#endif /* HAX_WIN32_SYS_FILE_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_SYS_FILE_H */

--- a/src/system/win32_include/sys/ioctl.h
+++ b/src/system/win32_include/sys/ioctl.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_SYS_IOCTL_H
+#define HAX_WIN32_SYS_IOCTL_H
+
+#define TIOCGWINSZ 1
+struct winsize {
+    unsigned short ws_row;
+    unsigned short ws_col;
+    unsigned short ws_xpixel;
+    unsigned short ws_ypixel;
+};
+int ioctl(int fd, int request, ...);
+
+#endif /* HAX_WIN32_SYS_IOCTL_H */

--- a/src/system/win32_include/sys/ioctl.h
+++ b/src/system/win32_include/sys/ioctl.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_SYS_IOCTL_H
-#define HAX_WIN32_SYS_IOCTL_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_SYS_IOCTL_H
+#define HAX_SYSTEM_WIN32_INCLUDE_SYS_IOCTL_H
 
 #define TIOCGWINSZ 1
 struct winsize {
@@ -11,4 +11,4 @@ struct winsize {
 };
 int ioctl(int fd, int request, ...);
 
-#endif /* HAX_WIN32_SYS_IOCTL_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_SYS_IOCTL_H */

--- a/src/system/win32_include/sys/utsname.h
+++ b/src/system/win32_include/sys/utsname.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_SYS_UTSNAME_H
-#define HAX_WIN32_SYS_UTSNAME_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_SYS_UTSNAME_H
+#define HAX_SYSTEM_WIN32_INCLUDE_SYS_UTSNAME_H
 
 struct utsname {
     char sysname[64];
@@ -11,4 +11,4 @@ struct utsname {
 };
 int uname(struct utsname *name);
 
-#endif /* HAX_WIN32_SYS_UTSNAME_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_SYS_UTSNAME_H */

--- a/src/system/win32_include/sys/utsname.h
+++ b/src/system/win32_include/sys/utsname.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_SYS_UTSNAME_H
+#define HAX_WIN32_SYS_UTSNAME_H
+
+struct utsname {
+    char sysname[64];
+    char nodename[256];
+    char release[64];
+    char version[128];
+    char machine[64];
+};
+int uname(struct utsname *name);
+
+#endif /* HAX_WIN32_SYS_UTSNAME_H */

--- a/src/system/win32_include/sys/wait.h
+++ b/src/system/win32_include/sys/wait.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_SYS_WAIT_H
-#define HAX_WIN32_SYS_WAIT_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_SYS_WAIT_H
+#define HAX_SYSTEM_WIN32_INCLUDE_SYS_WAIT_H
 
 #include <errno.h>
 #include <unistd.h>
@@ -11,6 +11,4 @@
 #define WIFSIGNALED(status) ((status) >= 256)
 #define WTERMSIG(status)    ((status) - 256)
 
-pid_t waitpid(pid_t pid, int *status, int options);
-
-#endif /* HAX_WIN32_SYS_WAIT_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_SYS_WAIT_H */

--- a/src/system/win32_include/sys/wait.h
+++ b/src/system/win32_include/sys/wait.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_SYS_WAIT_H
+#define HAX_WIN32_SYS_WAIT_H
+
+#include <errno.h>
+#include <unistd.h>
+
+#define WNOHANG             1
+#define WIFEXITED(status)   ((status) >= 0 && (status) < 256)
+#define WEXITSTATUS(status) (status)
+#define WIFSIGNALED(status) ((status) >= 256)
+#define WTERMSIG(status)    ((status) - 256)
+
+pid_t waitpid(pid_t pid, int *status, int options);
+
+#endif /* HAX_WIN32_SYS_WAIT_H */

--- a/src/system/win32_include/termios.h
+++ b/src/system/win32_include/termios.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_TERMIOS_H
-#define HAX_WIN32_TERMIOS_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_TERMIOS_H
+#define HAX_SYSTEM_WIN32_INCLUDE_TERMIOS_H
 
 #include <windows.h>
 
@@ -35,4 +35,4 @@ int tcgetattr(int fd, struct termios *attributes);
 int tcsetattr(int fd, int action, const struct termios *attributes);
 int tcflush(int fd, int queue);
 
-#endif /* HAX_WIN32_TERMIOS_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_TERMIOS_H */

--- a/src/system/win32_include/termios.h
+++ b/src/system/win32_include/termios.h
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_TERMIOS_H
+#define HAX_WIN32_TERMIOS_H
+
+#include <windows.h>
+
+typedef unsigned int tcflag_t;
+struct termios {
+    DWORD input_mode;
+    tcflag_t c_iflag;
+    tcflag_t c_oflag;
+    tcflag_t c_cflag;
+    tcflag_t c_lflag;
+    unsigned char c_cc[32];
+};
+
+#define ICANON    0x0001
+#define ECHO      0x0002
+#define ISIG      0x0004
+#define IEXTEN    0x0008
+#define IXON      0x0010
+#define ICRNL     0x0020
+#define OPOST     0x0040
+#define INPCK     0x0080
+#define ISTRIP    0x0100
+#define BRKINT    0x0200
+#define CS8       0x0400
+#define VMIN      0
+#define VTIME     1
+#define TCSANOW   0
+#define TCSADRAIN 1
+#define TCIFLUSH  0
+
+int tcgetattr(int fd, struct termios *attributes);
+int tcsetattr(int fd, int action, const struct termios *attributes);
+int tcflush(int fd, int queue);
+
+#endif /* HAX_WIN32_TERMIOS_H */

--- a/src/system/win32_include/unistd.h
+++ b/src/system/win32_include/unistd.h
@@ -1,0 +1,68 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_WIN32_UNISTD_H
+#define HAX_WIN32_UNISTD_H
+
+#include <io.h>
+#include <process.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/types.h>
+
+#ifndef STDIN_FILENO
+#define STDIN_FILENO  0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+#endif
+#ifndef F_OK
+#define F_OK 0
+#define X_OK 0
+#define W_OK 2
+#define R_OK 4
+#endif
+#ifndef O_CLOEXEC
+#define O_CLOEXEC 0
+#endif
+#ifndef O_NOCTTY
+#define O_NOCTTY 0
+#endif
+#ifndef O_NONBLOCK
+#define O_NONBLOCK 0
+#endif
+#ifndef O_DIRECTORY
+#define O_DIRECTORY 0
+#endif
+#ifndef O_NOFOLLOW
+#define O_NOFOLLOW 0
+#endif
+#ifndef SSIZE_MAX
+#define SSIZE_MAX INT_MAX
+#endif
+
+typedef intptr_t ssize_t;
+typedef int pid_t;
+typedef int mode_t;
+typedef long off_t;
+
+#define close            _close
+#define dup              _dup
+#define dup2             _dup2
+#define fileno           _fileno
+#define getpid           _getpid
+#define isatty           hax_isatty
+#define lseek            _lseek
+#define read             _read
+#define write            _write
+#define fdopen           _fdopen
+#define ftruncate        _chsize_s
+#define fsync            _commit
+#define fchmod(fd, mode) (0)
+#define pread            hax_pread
+
+int hax_pread(int fd, void *buffer, size_t count, off_t offset);
+int hax_isatty(int fd);
+int setenv(const char *name, const char *value, int overwrite);
+int unsetenv(const char *name);
+void hax_sleep_ms(long milliseconds);
+
+#endif /* HAX_WIN32_UNISTD_H */

--- a/src/system/win32_include/unistd.h
+++ b/src/system/win32_include/unistd.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MIT */
-#ifndef HAX_WIN32_UNISTD_H
-#define HAX_WIN32_UNISTD_H
+#ifndef HAX_SYSTEM_WIN32_INCLUDE_UNISTD_H
+#define HAX_SYSTEM_WIN32_INCLUDE_UNISTD_H
 
 #include <io.h>
 #include <process.h>
@@ -20,49 +20,51 @@
 #define W_OK 2
 #define R_OK 4
 #endif
+/* Keep compatibility flags outside UCRT's _O_* range so hax_open can enforce them before
+ * handing the native handle to the CRT. */
 #ifndef O_CLOEXEC
-#define O_CLOEXEC 0
+#define O_CLOEXEC 0x00100000
 #endif
 #ifndef O_NOCTTY
-#define O_NOCTTY 0
+#define O_NOCTTY 0x00200000
 #endif
 #ifndef O_NONBLOCK
-#define O_NONBLOCK 0
+#define O_NONBLOCK 0x00400000
 #endif
 #ifndef O_DIRECTORY
-#define O_DIRECTORY 0
+#define O_DIRECTORY 0x00800000
 #endif
 #ifndef O_NOFOLLOW
-#define O_NOFOLLOW 0
+#define O_NOFOLLOW 0x01000000
 #endif
 #ifndef SSIZE_MAX
 #define SSIZE_MAX INT_MAX
 #endif
 
 typedef intptr_t ssize_t;
-typedef int pid_t;
 typedef int mode_t;
 typedef long off_t;
 
-#define close            _close
-#define dup              _dup
-#define dup2             _dup2
-#define fileno           _fileno
-#define getpid           _getpid
-#define isatty           hax_isatty
-#define lseek            _lseek
-#define read             _read
-#define write            _write
-#define fdopen           _fdopen
-#define ftruncate        _chsize_s
-#define fsync            _commit
-#define fchmod(fd, mode) (0)
-#define pread            hax_pread
+#define close     _close
+#define dup       _dup
+#define dup2      _dup2
+#define fileno    _fileno
+#define getpid    _getpid
+#define isatty    hax_isatty
+#define lseek     _lseek
+#define read      _read
+#define write     _write
+#define fdopen    _fdopen
+#define ftruncate _chsize_s
+#define fsync     _commit
+#define fchmod    hax_fchmod
+#define pread     hax_pread
 
-int hax_pread(int fd, void *buffer, size_t count, off_t offset);
+int hax_fchmod(int fd, mode_t mode);
+ssize_t hax_pread(int fd, void *buffer, size_t count, off_t offset);
 int hax_isatty(int fd);
 int setenv(const char *name, const char *value, int overwrite);
 int unsetenv(const char *name);
 void hax_sleep_ms(long milliseconds);
 
-#endif /* HAX_WIN32_UNISTD_H */
+#endif /* HAX_SYSTEM_WIN32_INCLUDE_UNISTD_H */

--- a/src/terminal/clipboard_win32.c
+++ b/src/terminal/clipboard_win32.c
@@ -1,0 +1,143 @@
+/* SPDX-License-Identifier: MIT */
+#ifdef _WIN32
+
+#include <stdlib.h>
+#include <string.h>
+#include <windows.h>
+
+#include "util.h"
+#include "terminal/ansi.h"
+#include "terminal/clipboard.h"
+#include "text/base64.h"
+
+#define OSC52_PREFIX      ANSI_ESC "]52;c;"
+#define OSC52_SUFFIX      ANSI_BEL
+#define TMUX_OSC52_PREFIX ANSI_TMUX_PASSTHROUGH_BEGIN OSC52_PREFIX
+#define TMUX_OSC52_SUFFIX OSC52_SUFFIX ANSI_TMUX_PASSTHROUGH_END
+
+char *clipboard_osc52_sequence(const char *text, size_t text_len, int tmux_wrap, size_t *out_len)
+{
+    if (text_len > CLIPBOARD_OSC52_MAX_BYTES)
+        return NULL;
+    size_t encoded_len;
+    char *encoded = base64_encode(text, text_len, &encoded_len);
+    const char *prefix = tmux_wrap ? TMUX_OSC52_PREFIX : OSC52_PREFIX;
+    const char *suffix = tmux_wrap ? TMUX_OSC52_SUFFIX : OSC52_SUFFIX;
+    size_t prefix_len = strlen(prefix);
+    size_t suffix_len = strlen(suffix);
+    size_t sequence_len = prefix_len + encoded_len + suffix_len;
+    char *sequence = xmalloc(sequence_len + 1);
+    memcpy(sequence, prefix, prefix_len);
+    memcpy(sequence + prefix_len, encoded, encoded_len);
+    memcpy(sequence + prefix_len + encoded_len, suffix, suffix_len + 1);
+    free(encoded);
+    if (out_len)
+        *out_len = sequence_len;
+    return sequence;
+}
+
+static wchar_t *utf8_to_wide(const char *text, size_t length, size_t *wide_length)
+{
+    int count = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text, (int)length, NULL, 0);
+    if (count <= 0)
+        return NULL;
+    wchar_t *wide = xmalloc(((size_t)count + 1) * sizeof(*wide));
+    if (!MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text, (int)length, wide, count)) {
+        free(wide);
+        return NULL;
+    }
+    wide[count] = L'\0';
+    if (wide_length)
+        *wide_length = (size_t)count;
+    return wide;
+}
+
+int clipboard_copy(const char *text, size_t text_len, const char **error)
+{
+    if (error)
+        *error = NULL;
+    size_t wide_length;
+    wchar_t *wide = utf8_to_wide(text, text_len, &wide_length);
+    if (!wide) {
+        if (error)
+            *error = "clipboard text is not valid UTF-8";
+        return -1;
+    }
+    HGLOBAL memory = GlobalAlloc(GMEM_MOVEABLE, (wide_length + 1) * sizeof(*wide));
+    if (!memory) {
+        free(wide);
+        return -1;
+    }
+    void *destination = GlobalLock(memory);
+    memcpy(destination, wide, (wide_length + 1) * sizeof(*wide));
+    GlobalUnlock(memory);
+    free(wide);
+
+    if (!OpenClipboard(NULL)) {
+        GlobalFree(memory);
+        return -1;
+    }
+    EmptyClipboard();
+    HANDLE placed = SetClipboardData(CF_UNICODETEXT, memory);
+    CloseClipboard();
+    if (!placed) {
+        GlobalFree(memory);
+        return -1;
+    }
+    return 0;
+}
+
+char *clipboard_paste_text(size_t *out_len, long deadline_ms)
+{
+    (void)deadline_ms;
+    if (!OpenClipboard(NULL))
+        return NULL;
+    HANDLE memory = GetClipboardData(CF_UNICODETEXT);
+    const wchar_t *wide = memory ? GlobalLock(memory) : NULL;
+    char *result = NULL;
+    if (wide && *wide) {
+        int length =
+            WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wide, -1, NULL, 0, NULL, NULL);
+        if (length > 1) {
+            result = xmalloc((size_t)length);
+            WideCharToMultiByte(CP_UTF8, WC_ERR_INVALID_CHARS, wide, -1, result, length, NULL,
+                                NULL);
+            if (out_len)
+                *out_len = (size_t)length - 1;
+        }
+    }
+    if (wide)
+        GlobalUnlock(memory);
+    CloseClipboard();
+    return result;
+}
+
+char *clipboard_paste_image(size_t *out_len, long deadline_ms)
+{
+    (void)deadline_ms;
+    static const wchar_t *const FORMATS[] = {L"PNG",        L"image/png", L"JFIF",
+                                             L"image/jpeg", L"image/gif", L"image/webp"};
+    if (!OpenClipboard(NULL))
+        return NULL;
+    char *result = NULL;
+    for (size_t i = 0; !result && i < sizeof(FORMATS) / sizeof(*FORMATS); i++) {
+        UINT format = RegisterClipboardFormatW(FORMATS[i]);
+        HANDLE memory = GetClipboardData(format);
+        if (!memory)
+            continue;
+        SIZE_T length = GlobalSize(memory);
+        const void *bytes = GlobalLock(memory);
+        if (bytes && length > 0 && length <= (64u << 20)) {
+            result = xmalloc(length);
+            memcpy(result, bytes, length);
+            if (out_len)
+                *out_len = length;
+        }
+        if (bytes)
+            GlobalUnlock(memory);
+    }
+    CloseClipboard();
+    return result;
+}
+
+#endif /* _WIN32 */

--- a/src/terminal/interrupt.c
+++ b/src/terminal/interrupt.c
@@ -154,8 +154,13 @@ static enum input_event wait_for_input(int timeout_ms)
 static void drain_wake_pipe(void)
 {
     char bytes[64];
-    while (read(watcher.wake_read_fd, bytes, sizeof(bytes)) > 0)
-        continue;
+    for (;;) {
+        struct pollfd wake = {.fd = watcher.wake_read_fd, .events = POLLIN};
+        if (poll(&wake, 1, 0) <= 0 || !(wake.revents & POLLIN))
+            return;
+        if (read(watcher.wake_read_fd, bytes, sizeof(bytes)) <= 0)
+            return;
+    }
 }
 
 static int watcher_is_armed(void)

--- a/src/terminal/interrupt.c
+++ b/src/terminal/interrupt.c
@@ -304,24 +304,29 @@ void interrupt_install_fatal_signal_handlers(void)
 static int create_wake_pipe(void)
 {
     int fds[2];
-    /* pipe2 is unavailable on macOS; set CLOEXEC explicitly to keep watcher fds internal. */
+    /* Windows creates non-inheritable pipes and readiness-probes before each read; POSIX needs
+     * explicit CLOEXEC and nonblocking state to close the poll/read race. */
     if (pipe(fds) < 0)
         return -1;
+#ifndef _WIN32
     if (fcntl(fds[0], F_SETFD, FD_CLOEXEC) < 0 || fcntl(fds[1], F_SETFD, FD_CLOEXEC) < 0)
         goto fail;
 
     int flags = fcntl(fds[0], F_GETFL, 0);
     if (flags < 0 || fcntl(fds[0], F_SETFL, flags | O_NONBLOCK) < 0)
         goto fail;
+#endif
 
     watcher.wake_read_fd = fds[0];
     watcher.wake_write_fd = fds[1];
     return 0;
 
+#ifndef _WIN32
 fail:
     close(fds[0]);
     close(fds[1]);
     return -1;
+#endif
 }
 
 void interrupt_init(void)

--- a/src/terminal/windows.c
+++ b/src/terminal/windows.c
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: MIT */
+#ifdef _WIN32
+
+#include "terminal/windows.h"
+
+#include <io.h>
+#include <stdlib.h>
+#include <wchar.h>
+#include <windows.h>
+
+static int msys_pty_name(HANDLE handle)
+{
+    if (GetFileType(handle) != FILE_TYPE_PIPE)
+        return 0;
+
+    DWORD capacity = 4096;
+    FILE_NAME_INFO *name = malloc(capacity);
+    if (!name)
+        return 0;
+    int result = 0;
+    if (GetFileInformationByHandleEx(handle, FileNameInfo, name, capacity)) {
+        size_t chars = name->FileNameLength / sizeof(wchar_t);
+        wchar_t *copy = malloc((chars + 1) * sizeof(*copy));
+        if (copy) {
+            for (size_t i = 0; i < chars; i++) {
+                wchar_t value = name->FileName[i];
+                copy[i] = value >= L'A' && value <= L'Z' ? value - L'A' + L'a' : value;
+            }
+            copy[chars] = L'\0';
+            result = wcsstr(copy, L"msys-") && wcsstr(copy, L"-pty");
+            free(copy);
+        }
+    }
+    free(name);
+    return result;
+}
+
+enum terminal_stream_kind terminal_windows_stream_kind(int fd)
+{
+    intptr_t raw = _get_osfhandle(fd);
+    if (raw == -1)
+        return TERMINAL_STREAM_REDIRECTED;
+    HANDLE handle = (HANDLE)raw;
+    DWORD mode;
+    if (GetConsoleMode(handle, &mode))
+        return TERMINAL_STREAM_CONSOLE;
+    if (msys_pty_name(handle))
+        return TERMINAL_STREAM_MSYS_PTY;
+    return TERMINAL_STREAM_REDIRECTED;
+}
+
+#endif /* _WIN32 */

--- a/src/terminal/windows.h
+++ b/src/terminal/windows.h
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_TERMINAL_WINDOWS_H
+#define HAX_TERMINAL_WINDOWS_H
+
+#ifdef _WIN32
+
+enum terminal_stream_kind {
+    TERMINAL_STREAM_CONSOLE,
+    TERMINAL_STREAM_MSYS_PTY,
+    TERMINAL_STREAM_REDIRECTED,
+};
+
+/* Classify a CRT descriptor without changing its console mode. */
+enum terminal_stream_kind terminal_windows_stream_kind(int fd);
+
+#endif /* _WIN32 */
+#endif /* HAX_TERMINAL_WINDOWS_H */

--- a/src/text/utf8.c
+++ b/src/text/utf8.c
@@ -104,7 +104,7 @@ size_t utf8_prev(const char *bytes, size_t offset)
 /* Terminal format controls can hide or reorder content even when libc assigns them zero width.
  * Variation selectors remain available for emoji presentation, though substituting ZWJ can break
  * joined emoji sequences. */
-static int codepoint_requires_substitution(wchar_t codepoint)
+static int codepoint_requires_substitution(uint32_t codepoint)
 {
     if (codepoint == 0x00AD) /* soft hyphen */
         return 1;
@@ -137,6 +137,63 @@ static int codepoint_requires_substitution(wchar_t codepoint)
     return 0;
 }
 
+#ifdef _WIN32
+static int windows_codepoint_cells(uint32_t codepoint)
+{
+    if (codepoint == 0)
+        return 0;
+    if (codepoint < 0x20 || (codepoint >= 0x7f && codepoint < 0xa0))
+        return -1;
+    if ((codepoint >= 0x0300 && codepoint <= 0x036f) ||
+        (codepoint >= 0x1ab0 && codepoint <= 0x1aff) ||
+        (codepoint >= 0x1dc0 && codepoint <= 0x1dff) ||
+        (codepoint >= 0x20d0 && codepoint <= 0x20ff) ||
+        (codepoint >= 0xfe00 && codepoint <= 0xfe0f) ||
+        (codepoint >= 0xfe20 && codepoint <= 0xfe2f) ||
+        (codepoint >= 0xe0100 && codepoint <= 0xe01ef))
+        return 0;
+    if ((codepoint >= 0x1100 && codepoint <= 0x115f) ||
+        (codepoint >= 0x2329 && codepoint <= 0x232a) ||
+        (codepoint >= 0x2e80 && codepoint <= 0xa4cf) ||
+        (codepoint >= 0xac00 && codepoint <= 0xd7a3) ||
+        (codepoint >= 0xf900 && codepoint <= 0xfaff) ||
+        (codepoint >= 0xfe10 && codepoint <= 0xfe6f) ||
+        (codepoint >= 0xff00 && codepoint <= 0xff60) ||
+        (codepoint >= 0xffe0 && codepoint <= 0xffe6) ||
+        (codepoint >= 0x1f300 && codepoint <= 0x1faff) ||
+        (codepoint >= 0x20000 && codepoint <= 0x3fffd))
+        return 2;
+    return 1;
+}
+
+static int decode_utf8_scalar(const unsigned char *bytes, size_t available, uint32_t *codepoint,
+                              size_t *decoded_len)
+{
+    size_t length = utf8_sequence_length(bytes[0]);
+    if (length == 1) {
+        if (bytes[0] >= 0x80)
+            return -1;
+        *codepoint = bytes[0];
+        *decoded_len = 1;
+        return 0;
+    }
+    if (length > available)
+        return -1;
+    uint32_t value = bytes[0] & (0x7f >> length);
+    for (size_t i = 1; i < length; i++) {
+        if ((bytes[i] & 0xc0) != 0x80)
+            return -1;
+        value = (value << 6) | (bytes[i] & 0x3f);
+    }
+    uint32_t minimum = length == 2 ? 0x80 : length == 3 ? 0x800 : 0x10000;
+    if (value < minimum || value > 0x10ffff || (value >= 0xd800 && value <= 0xdfff))
+        return -1;
+    *codepoint = value;
+    *decoded_len = length;
+    return 0;
+}
+#endif
+
 int utf8_codepoint_cells(const char *bytes, size_t length, size_t offset, size_t *codepoint_len)
 {
     if (offset >= length) {
@@ -144,18 +201,33 @@ int utf8_codepoint_cells(const char *bytes, size_t length, size_t offset, size_t
         return 0;
     }
 
-    wchar_t codepoint;
+#ifdef _WIN32
+    uint32_t codepoint;
+    size_t decoded_len;
+    if (decode_utf8_scalar((const unsigned char *)bytes + offset, length - offset, &codepoint,
+                           &decoded_len) != 0) {
+        *codepoint_len = 1;
+        return -1;
+    }
+#else
+    wchar_t decoded;
     mbstate_t state = {0};
-    size_t decoded_len = mbrtowc(&codepoint, bytes + offset, length - offset, &state);
+    size_t decoded_len = mbrtowc(&decoded, bytes + offset, length - offset, &state);
     if (decoded_len == (size_t)-1 || decoded_len == (size_t)-2 || decoded_len == 0) {
         *codepoint_len = 1;
         return -1;
     }
+    uint32_t codepoint = (uint32_t)decoded;
+#endif
 
     *codepoint_len = decoded_len;
     if (codepoint_requires_substitution(codepoint))
         return -1;
-    return wcwidth(codepoint);
+#ifdef _WIN32
+    return windows_codepoint_cells(codepoint);
+#else
+    return wcwidth((wchar_t)codepoint);
+#endif
 }
 
 void utf8_cell_stream_reset(struct utf8_cell_stream *stream)

--- a/src/tools/bash_output.c
+++ b/src/tools/bash_output.c
@@ -7,9 +7,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/types.h>
-/* The wait macros are provided by <sys/wait.h> per POSIX; glibc also leaks
- * them through <stdlib.h>, so the include cleaner cannot attribute them. */
-#include <sys/wait.h> // IWYU pragma: keep
 
 #include "util.h"
 #include "system/tempfiles.h"
@@ -300,7 +297,7 @@ int bash_read_tail_slice(int fd, off_t range_start, size_t range_bytes, size_t c
 }
 
 static void append_status(struct buf *out, enum bash_stop_reason reason, long timeout_ms,
-                          int wait_status)
+                          const struct spawn_status *status)
 {
     if (reason == BASH_STOP_INTERRUPT) {
         buf_append_str(out, "\n[interrupted]");
@@ -314,17 +311,16 @@ static void append_status(struct buf *out, enum bash_stop_reason reason, long ti
         buf_append_str(out, footer);
         return;
     }
-    if (WIFEXITED(wait_status)) {
-        int code = WEXITSTATUS(wait_status);
-        if (code != 0) {
-            char footer[64];
-            snprintf(footer, sizeof(footer), "\n[exit %d]", code);
-            buf_append_str(out, footer);
-        }
-    } else if (WIFSIGNALED(wait_status)) {
+    if (status->end == SPAWN_END_EXITED && status->code != 0) {
         char footer[64];
-        snprintf(footer, sizeof(footer), "\n[signal %d]", WTERMSIG(wait_status));
+        snprintf(footer, sizeof(footer), "\n[exit %d]", status->code);
         buf_append_str(out, footer);
+    } else if (status->end == SPAWN_END_SIGNALED) {
+        char footer[64];
+        snprintf(footer, sizeof(footer), "\n[signal %d]", status->code);
+        buf_append_str(out, footer);
+    } else if (status->end == SPAWN_END_FORCED && reason == BASH_STOP_NONE) {
+        buf_append_str(out, "\n[terminated]");
     }
     if (reason == BASH_STOP_ORPHANED) {
         char formatted_timeout[32];
@@ -339,7 +335,8 @@ static void append_status(struct buf *out, enum bash_stop_reason reason, long ti
 }
 
 static void append_run_suffix(struct buf *out, size_t total_bytes, int binary, int body_present,
-                              enum bash_stop_reason reason, long timeout_ms, int wait_status)
+                              enum bash_stop_reason reason, long timeout_ms,
+                              const struct spawn_status *status)
 {
     size_t before = out->len;
     if (binary) {
@@ -349,7 +346,7 @@ static void append_run_suffix(struct buf *out, size_t total_bytes, int binary, i
         snprintf(marker, sizeof(marker), "[binary output suppressed: %s]", total_size);
         buf_append_str(out, marker);
     }
-    append_status(out, reason, timeout_ms, wait_status);
+    append_status(out, reason, timeout_ms, status);
     if (out->len == before && !body_present)
         buf_append_str(out, "(no output)");
 }
@@ -509,22 +506,23 @@ void bash_output_reattach_file(struct bash_output *output, int fd, char *path)
 }
 
 char *bash_output_format_suffix(size_t total_bytes, int binary, int body_present,
-                                enum bash_stop_reason reason, long timeout_ms, int wait_status)
+                                enum bash_stop_reason reason, long timeout_ms,
+                                const struct spawn_status *status)
 {
     struct buf suffix;
     buf_init(&suffix);
-    append_run_suffix(&suffix, total_bytes, binary, body_present, reason, timeout_ms, wait_status);
+    append_run_suffix(&suffix, total_bytes, binary, body_present, reason, timeout_ms, status);
     return buf_steal(&suffix);
 }
 
 char *bash_output_finish(struct bash_output *output, int binary, enum bash_stop_reason reason,
-                         long timeout_ms, int wait_status)
+                         long timeout_ms, const struct spawn_status *status)
 {
     struct buf result;
     buf_init(&result);
     build_model_body(output, binary, &result);
     append_run_suffix(&result, output->total_bytes, binary, result.len > 0, reason, timeout_ms,
-                      wait_status);
+                      status);
     return buf_steal(&result);
 }
 

--- a/src/tools/bash_output.h
+++ b/src/tools/bash_output.h
@@ -5,6 +5,8 @@
 #include <stddef.h>
 #include <sys/types.h>
 
+#include "system/spawn.h"
+
 struct buf;
 
 #define BASH_OUTPUT_DRAIN_LIMIT (16L * 1024 * 1024)
@@ -34,11 +36,12 @@ void bash_output_reattach_file(struct bash_output *output, int fd, char *path);
 
 /* Return an owned sanitized result, including truncation and status markers. */
 char *bash_output_finish(struct bash_output *output, int binary, enum bash_stop_reason reason,
-                         long timeout_ms, int wait_status);
+                         long timeout_ms, const struct spawn_status *status);
 
 /* Return an owned status suffix for output already sent to the live display. */
 char *bash_output_format_suffix(size_t total_bytes, int binary, int body_present,
-                                enum bash_stop_reason reason, long timeout_ms, int wait_status);
+                                enum bash_stop_reason reason, long timeout_ms,
+                                const struct spawn_status *status);
 
 /* Compact human size: "12B", "1.2K", "40K", "1.5M". */
 void bash_format_byte_size(char *buf, size_t buf_size, size_t bytes);

--- a/src/tools/bash_process.c
+++ b/src/tools/bash_process.c
@@ -2,7 +2,6 @@
 #include "tools/bash_process.h"
 
 #include <errno.h>
-#include <fcntl.h>
 #include <limits.h>
 #include <poll.h>
 #include <signal.h>
@@ -10,8 +9,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 
 #include "config.h"
 #include "tool.h"
@@ -25,7 +22,7 @@
 #include "tools/task_registry.h"
 
 struct shell_process {
-    pid_t pid;
+    struct spawn_process *process;
     int output_fd;
 };
 
@@ -34,112 +31,51 @@ static long deadline_after(long now_ms, long duration_ms)
     return duration_ms > LONG_MAX - now_ms ? LONG_MAX : now_ms + duration_ms;
 }
 
-void bash_signal_process_tree(pid_t pid, int signal_number)
+static void bash_signal_process_tree(struct spawn_process *process, int signal_number)
 {
-#ifdef _WIN32
-    (void)signal_number;
-    spawn_win32_terminate(pid);
-#else
-    /* The child creates its process group after fork, hence the fallback. */
-    if (kill(-pid, signal_number) < 0 && errno == ESRCH)
-        kill(pid, signal_number);
-#endif
+    spawn_process_terminate(process, signal_number);
 }
-
-#ifndef _WIN32
-/* This runs after fork in a multithreaded process; use only async-signal-safe calls. */
-static void exec_shell_child(const char *shell, const char *argv0, const char *command,
-                             char *const envp[])
-{
-    close(STDIN_FILENO);
-    (void)open("/dev/null", O_RDONLY);
-    char *const argv[] = {(char *)argv0, (char *)"-c", (char *)command, NULL};
-    execve(shell, argv, envp);
-    _exit(127);
-}
-#endif
 
 static char *start_shell(const char *command, struct shell_process *process)
 {
     char **envp = bash_build_child_env();
-#ifdef _WIN32
-    if (spawn_win32_start_bash(command, envp, &process->pid, &process->output_fd) != 0) {
-        char *error = xasprintf("starting Git Bash: %s", strerror(errno));
-        free(envp);
-        return error;
-    }
-    free(envp);
-#else
-    /* Resolve everything before fork so the child can avoid allocator and environment locks. */
-    char *shell = bash_resolve_shell();
-    const char *argv0 = strrchr(shell, '/');
+    char *shell = NULL;
+    const char *argv0 = NULL;
+#ifndef _WIN32
+    shell = bash_resolve_shell();
+    argv0 = strrchr(shell, '/');
     argv0 = argv0 ? argv0 + 1 : shell;
-
-    int pipe_fds[2];
-    if (pipe(pipe_fds) < 0) {
-        char *error = xasprintf("pipe: %s", strerror(errno));
-        free(shell);
-        free(envp);
-        return error;
-    }
-
-    pid_t parent_pid = getpid();
-    pid_t pid = fork();
-    if (pid < 0) {
-        char *error = xasprintf("fork: %s", strerror(errno));
-        close(pipe_fds[0]);
-        close(pipe_fds[1]);
-        free(shell);
-        free(envp);
-        return error;
-    }
-    if (pid == 0) {
-        close(pipe_fds[0]);
-        /* A separate session isolates descendants and removes access to the agent's terminal. */
-        setsid();
-        /* Backstop for a hax death no handler can see (SIGKILL, OOM): pdeathsig survives the
-         * execve, so an exec-optimized `bash -c` leader dies with hax even then. SIGKILL,
-         * not SIGTERM — a command that traps TERM must not outlive a dead hax either. */
-        spawn_child_die_with_parent(parent_pid, SIGKILL);
-        dup2(pipe_fds[1], STDOUT_FILENO);
-        dup2(pipe_fds[1], STDERR_FILENO);
-        if (pipe_fds[1] > STDERR_FILENO)
-            close(pipe_fds[1]);
-        exec_shell_child(shell, argv0, command, envp);
-    }
-
-    close(pipe_fds[1]);
+#endif
+    process->process = spawn_process_start_bash(shell, argv0, command, envp, &process->output_fd);
     free(shell);
     free(envp);
-    process->pid = pid;
-    process->output_fd = pipe_fds[0];
-#endif
-    bash_shell_pgid_publish(process->pid);
+    if (!process->process)
+        return xasprintf("starting Bash: %s", strerror(errno));
+    bash_live_process_publish(process->process);
     return NULL;
 }
 
 /* Return the grace deadline, or 0 when the process tree was killed immediately. */
-static long start_shutdown(pid_t pid, long now_ms, long grace_ms)
-{
-    if (grace_ms <= 0) {
-        bash_signal_process_tree(pid, SIGKILL);
-        return 0;
-    }
-    bash_signal_process_tree(pid, SIGTERM);
-    return deadline_after(now_ms, grace_ms);
-}
-
-int bash_process_exit_seen(pid_t pid, int *exit_seen)
+static long start_shutdown(struct spawn_process *process, long now_ms, long grace_ms)
 {
 #ifdef _WIN32
-    return spawn_win32_exit_seen(pid, exit_seen);
+    (void)now_ms;
+    (void)grace_ms;
+    bash_signal_process_tree(process, SIGKILL);
+    return 0;
 #else
-    siginfo_t info = {0};
-    int result = waitid(P_PID, (id_t)pid, &info, WEXITED | WNOHANG | WNOWAIT);
-    if (result == 0 && info.si_pid == pid)
-        *exit_seen = 1;
-    return result;
+    if (grace_ms <= 0) {
+        bash_signal_process_tree(process, SIGKILL);
+        return 0;
+    }
+    bash_signal_process_tree(process, SIGTERM);
+    return deadline_after(now_ms, grace_ms);
 #endif
+}
+
+static int bash_process_exit_seen(struct spawn_process *process, int *exit_seen)
+{
+    return spawn_process_exit_seen(process, exit_seen);
 }
 
 /* Generous: a loaded machine may schedule the exiting shell late, and the stall lands only on
@@ -160,13 +96,13 @@ static size_t transition_min_bytes(void)
     return value ? (size_t)strtoul(value, NULL, 10) : 0;
 }
 
-/* Wait up to `timeout_ms` for the shell's exit to become observable, probing with WNOWAIT so
- * the zombie keeps the process group signalable. Returns -1 when the wait itself fails. */
-static int observe_shell_exit(pid_t pid, int *exit_seen, long timeout_ms)
+/* Wait up to `timeout_ms` for the shell's exit to become observable without consuming the
+ * process object, so its tree remains terminable. Returns -1 when the wait itself fails. */
+static int observe_shell_exit(struct spawn_process *process, int *exit_seen, long timeout_ms)
 {
     long deadline = deadline_after(monotonic_ms(), timeout_ms);
     while (!*exit_seen) {
-        if (bash_process_exit_seen(pid, exit_seen) < 0 && errno != EINTR)
+        if (bash_process_exit_seen(process, exit_seen) < 0 && errno != EINTR)
             return -1;
         if (*exit_seen || monotonic_ms() >= deadline)
             break;
@@ -204,10 +140,10 @@ static int poll_timeout_ms(long deadline)
 
 static void display_suffix(tool_display_fn display, void *display_data, size_t total_bytes,
                            int binary, int displayed_body, enum bash_stop_reason reason,
-                           long timeout_ms, int wait_status)
+                           long timeout_ms, const struct spawn_status *status)
 {
-    char *suffix = bash_output_format_suffix(total_bytes, binary, displayed_body, reason,
-                                             timeout_ms, wait_status);
+    char *suffix =
+        bash_output_format_suffix(total_bytes, binary, displayed_body, reason, timeout_ms, status);
 
     /* A newline aborts any unterminated escape sequence before the binary marker's '['. */
     if (binary && displayed_body)
@@ -231,7 +167,7 @@ static char *adopt_running_command(const struct shell_process *process, const ch
     int spool_fd = bash_output_detach_file(output, &spool_path);
     if (spool_fd < 0)
         return NULL;
-    const char *id = task_adopt(process->pid, process->output_fd, command, name, started_ms,
+    const char *id = task_adopt(process->process, process->output_fd, command, name, started_ms,
                                 spool_fd, spool_path, bash_output_size(output), binary, pipe_eof);
     if (!id) {
         bash_output_reattach_file(output, spool_fd, spool_path);
@@ -310,7 +246,7 @@ char *bash_run_command(const char *command, long timeout_ms, int background, con
     long exit_flush_deadline = 0;
     enum bash_stop_reason stop_reason = BASH_STOP_NONE;
     int shell_exited = 0;
-    int wait_status = 0;
+    struct spawn_status status = {.end = SPAWN_END_FORCED};
     int binary = 0;
     int displayed_body = 0;
     struct bash_output *output = bash_output_create(output_cap_bytes());
@@ -325,13 +261,13 @@ char *bash_run_command(const char *command, long timeout_ms, int background, con
             transition_deadline = hold_cap;
 
         /* Probe before the deadline check so adoption never takes a shell that has already
-         * exited. WNOWAIT keeps the pid reserved until all process-tree signaling is done. */
+         * exited. The process object stays owned until all tree termination is done. */
         if (!shell_exited) {
-            int status_result = bash_process_exit_seen(process.pid, &shell_exited);
+            int status_result = bash_process_exit_seen(process.process, &shell_exited);
             /* Reaping stragglers on shell exit would defeat an explicit background request,
              * where lingering children are the point. */
             if (shell_exited && stop_reason == BASH_STOP_NONE && !background)
-                bash_signal_process_tree(process.pid, SIGKILL);
+                bash_signal_process_tree(process.process, SIGKILL);
             else if (status_result < 0 && errno != EINTR)
                 break;
         }
@@ -342,10 +278,10 @@ char *bash_run_command(const char *command, long timeout_ms, int background, con
             if (shell_exited) {
                 /* Background suppressed the shell-exit kill; orphans die on the way out. */
                 if (background)
-                    bash_signal_process_tree(process.pid, SIGKILL);
+                    bash_signal_process_tree(process.process, SIGKILL);
                 break;
             }
-            grace_deadline = start_shutdown(process.pid, now_ms, grace_ms);
+            grace_deadline = start_shutdown(process.process, now_ms, grace_ms);
             if (grace_deadline == 0)
                 break;
         }
@@ -355,7 +291,7 @@ char *bash_run_command(const char *command, long timeout_ms, int background, con
              * moments before its exit becomes waitable; let the exit land so the
              * adopt-vs-orphan choice below reflects the shell's state, not that race. */
             if (background && hold_min_bytes && !shell_exited)
-                observe_shell_exit(process.pid, &shell_exited, YIELD_EXIT_OBSERVE_MS);
+                observe_shell_exit(process.process, &shell_exited, YIELD_EXIT_OBSERVE_MS);
             int flush_pending = background && shell_exited &&
                                 exited_pipe_flush_pending(process.output_fd, &exit_flush_deadline);
             if (!flush_pending) {
@@ -375,17 +311,17 @@ char *bash_run_command(const char *command, long timeout_ms, int background, con
                 if (shell_exited) {
                     if (background) {
                         stop_reason = BASH_STOP_ORPHANED;
-                        bash_signal_process_tree(process.pid, SIGKILL);
+                        bash_signal_process_tree(process.process, SIGKILL);
                     }
                     break;
                 }
-                grace_deadline = start_shutdown(process.pid, now_ms, grace_ms);
+                grace_deadline = start_shutdown(process.process, now_ms, grace_ms);
                 if (grace_deadline == 0)
                     break;
             }
         }
         if (stop_reason != BASH_STOP_NONE && grace_deadline > 0 && now_ms >= grace_deadline) {
-            bash_signal_process_tree(process.pid, SIGKILL);
+            bash_signal_process_tree(process.process, SIGKILL);
             break;
         }
 
@@ -415,8 +351,8 @@ char *bash_run_command(const char *command, long timeout_ms, int background, con
              * atexit handler); a kill in that window would rewrite the exit status to SIGKILL,
              * so let a finishing shell's exit land first. */
             if (stop_reason == BASH_STOP_NONE)
-                observe_shell_exit(process.pid, &shell_exited, EOF_EXIT_OBSERVE_MS);
-            bash_signal_process_tree(process.pid, SIGKILL);
+                observe_shell_exit(process.process, &shell_exited, EOF_EXIT_OBSERVE_MS);
+            bash_signal_process_tree(process.process, SIGKILL);
             break;
         }
 
@@ -428,7 +364,7 @@ char *bash_run_command(const char *command, long timeout_ms, int background, con
         }
         bash_output_append(output, chunk, (size_t)bytes_read);
         if (bash_output_size(output) >= (size_t)BASH_OUTPUT_DRAIN_LIMIT) {
-            bash_signal_process_tree(process.pid, SIGKILL);
+            bash_signal_process_tree(process.process, SIGKILL);
             break;
         }
     }
@@ -437,7 +373,7 @@ char *bash_run_command(const char *command, long timeout_ms, int background, con
      * detaches as a task instead. */
     if (background && stop_reason == BASH_STOP_NONE) {
         int observe_failed =
-            observe_shell_exit(process.pid, &shell_exited, YIELD_EXIT_OBSERVE_MS) < 0;
+            observe_shell_exit(process.process, &shell_exited, YIELD_EXIT_OBSERVE_MS) < 0;
         if (!shell_exited && !observe_failed) {
             char *adopted =
                 adopt_running_command(&process, command, name, output, binary, background,
@@ -449,16 +385,14 @@ char *bash_run_command(const char *command, long timeout_ms, int background, con
         }
         /* An exited shell may leave orphans that redirected their output elsewhere; nothing
          * can track them, so kill the group while the unreaped zombie still reserves it. */
-        bash_signal_process_tree(process.pid, SIGKILL);
+        bash_signal_process_tree(process.process, SIGKILL);
     }
 
     close(process.output_fd);
 
-    bash_shell_pgid_retract(process.pid);
-    while (waitpid(process.pid, &wait_status, 0) < 0) {
-        if (errno != EINTR)
-            break;
-    }
+    bash_live_process_retract(process.process);
+    (void)spawn_process_wait(process.process, &status);
+    process.process = NULL;
 
     /* A background request that completed inside the yield window never created a task; name
      * the handle the model might otherwise wait on. The note is model-only: the user never saw
@@ -477,8 +411,8 @@ char *bash_run_command(const char *command, long timeout_ms, int background, con
      * background runs, the timeout otherwise (transition_ms covers both). */
     if (display)
         display_suffix(display, display_data, bash_output_size(output), binary, displayed_body,
-                       stop_reason, transition_ms, wait_status);
-    char *result = bash_output_finish(output, binary, stop_reason, transition_ms, wait_status);
+                       stop_reason, transition_ms, &status);
+    char *result = bash_output_finish(output, binary, stop_reason, transition_ms, &status);
     if (*task_footer) {
         char *with_footer = xasprintf("%s%s", result, task_footer);
         free(result);
@@ -492,27 +426,27 @@ char *bash_run_command(const char *command, long timeout_ms, int background, con
 
 /* Exceeds task.max_running's ceiling (64) plus the one foreground shell, so a free slot always
  * exists and publish cannot silently drop a shell. */
-#define SHELL_PGID_TABLE_SIZE 128
+#define LIVE_PROCESS_TABLE_SIZE 128
 
-/* Single-writer (the tool-dispatch thread); a fatal-signal handler may read concurrently, so
- * slots hold either zero or a pid whose process is still unreaped. */
-static volatile pid_t shell_pgids[SHELL_PGID_TABLE_SIZE];
+/* Single-writer (the tool-dispatch thread); fatal cleanup may read concurrently. Every pointer
+ * remains valid until it is retracted immediately before the consuming wait. */
+static struct spawn_process *volatile live_processes[LIVE_PROCESS_TABLE_SIZE];
 
-void bash_shell_pgid_publish(pid_t pid)
+void bash_live_process_publish(struct spawn_process *process)
 {
-    for (size_t i = 0; i < SHELL_PGID_TABLE_SIZE; i++) {
-        if (shell_pgids[i] == 0) {
-            shell_pgids[i] = pid;
+    for (size_t i = 0; i < LIVE_PROCESS_TABLE_SIZE; i++) {
+        if (!live_processes[i]) {
+            live_processes[i] = process;
             return;
         }
     }
 }
 
-void bash_shell_pgid_retract(pid_t pid)
+void bash_live_process_retract(struct spawn_process *process)
 {
-    for (size_t i = 0; i < SHELL_PGID_TABLE_SIZE; i++) {
-        if (shell_pgids[i] == pid) {
-            shell_pgids[i] = 0;
+    for (size_t i = 0; i < LIVE_PROCESS_TABLE_SIZE; i++) {
+        if (live_processes[i] == process) {
+            live_processes[i] = NULL;
             return;
         }
     }
@@ -520,9 +454,9 @@ void bash_shell_pgid_retract(pid_t pid)
 
 void bash_shell_pgids_kill(void)
 {
-    for (size_t i = 0; i < SHELL_PGID_TABLE_SIZE; i++) {
-        pid_t pid = shell_pgids[i];
-        if (pid > 0)
-            bash_signal_process_tree(pid, SIGKILL);
+    for (size_t i = 0; i < LIVE_PROCESS_TABLE_SIZE; i++) {
+        struct spawn_process *process = live_processes[i];
+        if (process)
+            bash_signal_process_tree(process, SIGKILL);
     }
 }

--- a/src/tools/bash_process.c
+++ b/src/tools/bash_process.c
@@ -34,13 +34,19 @@ static long deadline_after(long now_ms, long duration_ms)
     return duration_ms > LONG_MAX - now_ms ? LONG_MAX : now_ms + duration_ms;
 }
 
-/* The child creates its process group after fork, hence the fallback. */
 void bash_signal_process_tree(pid_t pid, int signal_number)
 {
+#ifdef _WIN32
+    (void)signal_number;
+    spawn_win32_terminate(pid);
+#else
+    /* The child creates its process group after fork, hence the fallback. */
     if (kill(-pid, signal_number) < 0 && errno == ESRCH)
         kill(pid, signal_number);
+#endif
 }
 
+#ifndef _WIN32
 /* This runs after fork in a multithreaded process; use only async-signal-safe calls. */
 static void exec_shell_child(const char *shell, const char *argv0, const char *command,
                              char *const envp[])
@@ -51,11 +57,20 @@ static void exec_shell_child(const char *shell, const char *argv0, const char *c
     execve(shell, argv, envp);
     _exit(127);
 }
+#endif
 
 static char *start_shell(const char *command, struct shell_process *process)
 {
-    /* Resolve everything before fork so the child can avoid allocator and environment locks. */
     char **envp = bash_build_child_env();
+#ifdef _WIN32
+    if (spawn_win32_start_bash(command, envp, &process->pid, &process->output_fd) != 0) {
+        char *error = xasprintf("starting Git Bash: %s", strerror(errno));
+        free(envp);
+        return error;
+    }
+    free(envp);
+#else
+    /* Resolve everything before fork so the child can avoid allocator and environment locks. */
     char *shell = bash_resolve_shell();
     const char *argv0 = strrchr(shell, '/');
     argv0 = argv0 ? argv0 + 1 : shell;
@@ -96,9 +111,10 @@ static char *start_shell(const char *command, struct shell_process *process)
     close(pipe_fds[1]);
     free(shell);
     free(envp);
-    bash_shell_pgid_publish(pid);
     process->pid = pid;
     process->output_fd = pipe_fds[0];
+#endif
+    bash_shell_pgid_publish(process->pid);
     return NULL;
 }
 
@@ -115,11 +131,15 @@ static long start_shutdown(pid_t pid, long now_ms, long grace_ms)
 
 int bash_process_exit_seen(pid_t pid, int *exit_seen)
 {
+#ifdef _WIN32
+    return spawn_win32_exit_seen(pid, exit_seen);
+#else
     siginfo_t info = {0};
     int result = waitid(P_PID, (id_t)pid, &info, WEXITED | WNOHANG | WNOWAIT);
     if (result == 0 && info.si_pid == pid)
         *exit_seen = 1;
     return result;
+#endif
 }
 
 /* Generous: a loaded machine may schedule the exiting shell late, and the stall lands only on
@@ -503,6 +523,6 @@ void bash_shell_pgids_kill(void)
     for (size_t i = 0; i < SHELL_PGID_TABLE_SIZE; i++) {
         pid_t pid = shell_pgids[i];
         if (pid > 0)
-            kill(-pid, SIGKILL);
+            bash_signal_process_tree(pid, SIGKILL);
     }
 }

--- a/src/tools/bash_process.h
+++ b/src/tools/bash_process.h
@@ -2,9 +2,9 @@
 #ifndef HAX_TOOLS_BASH_PROCESS_H
 #define HAX_TOOLS_BASH_PROCESS_H
 
-#include <sys/types.h>
-
 #include "tool.h"
+
+struct spawn_process;
 
 /* Run the command and return owned model-facing output, streaming display bytes through `ctx`
  * (NULL disables display). When background is set, the command detaches into a task after the
@@ -14,20 +14,9 @@
 char *bash_run_command(const char *command, long timeout_ms, int background, const char *name,
                        struct tool_run_ctx *ctx);
 
-/* Signal the command's process group, falling back to the pid when the group is not yet (or no
- * longer) alive. The pid must be unreaped. */
-void bash_signal_process_tree(pid_t pid, int signal_number);
-
-/* Observe the shell's exit without reaping it, so the zombie keeps the pid and process group
- * reserved for signaling. Sets *exit_seen on exit; returns waitid's result. */
-int bash_process_exit_seen(pid_t pid, int *exit_seen);
-
-/* Fatal-signal cleanup registry of live shell process groups. Shells are published at spawn and
- * retracted before the reap that frees the pid for reuse, so a handler firing in between can
- * only ever signal a group hax still owns. Publish/retract run on the tool-dispatch thread;
- * kill is async-signal-safe and may run from a signal handler. */
-void bash_shell_pgid_publish(pid_t pid);
-void bash_shell_pgid_retract(pid_t pid);
+/* Fatal-signal cleanup registry. Processes remain published until the wait consumes them. */
+void bash_live_process_publish(struct spawn_process *process);
+void bash_live_process_retract(struct spawn_process *process);
 void bash_shell_pgids_kill(void);
 
 #endif /* HAX_TOOLS_BASH_PROCESS_H */

--- a/src/tools/bash_shell.c
+++ b/src/tools/bash_shell.c
@@ -6,9 +6,13 @@
 #include "config.h"
 #include "util.h"
 #include "system/fs.h"
+#include "system/spawn.h"
 
 char *bash_resolve_shell(void)
 {
+#ifdef _WIN32
+    return spawn_win32_bash_path();
+#else
     const char *configured_shell = config_str("bash.shell");
     if (configured_shell && *configured_shell) {
         char *shell_path = fs_which(configured_shell);
@@ -28,4 +32,5 @@ char *bash_resolve_shell(void)
     if (access("/bin/bash", X_OK) == 0)
         return xstrdup("/bin/bash");
     return xstrdup("/bin/sh");
+#endif
 }

--- a/src/tools/task_registry.c
+++ b/src/tools/task_registry.c
@@ -11,13 +11,12 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 
 #include "config.h"
 #include "tool.h"
 #include "util.h"
 #include "system/bg_job.h"
+#include "system/spawn.h"
 #include "terminal/interrupt.h"
 #include "text/utf8_sanitize.h"
 #include "text/width.h"
@@ -36,7 +35,7 @@ struct task {
     struct task *next;
     char id[TASK_NAME_MAX + 1];
     char *command;
-    pid_t pid;
+    struct spawn_process *process;
     int pipe_fd;  /* -1 once the drainer is joined */
     int spool_fd; /* -1 when the spool could not be created */
     char *spool_path;
@@ -55,9 +54,9 @@ struct task {
 
     /* Main thread only. */
     int exit_seen;      /* shell exit observed unreaped; the zombie keeps the group signalable */
-    int done;           /* shell reaped after pipe EOF; wait_status valid; no further signaling */
+    int done;           /* shell reaped after pipe EOF; status valid; no further termination */
     int orphans_killed; /* descendants outlived the shell holding the pipe and were killed */
-    int wait_status;
+    struct spawn_status status;
     long kill_deadline_ms; /* nonzero after SIGTERM until escalation */
     /* Completion is announced once (notified) but the task stays collectable until a wait
      * delivers its remaining output (collected); only then is it forgotten. */
@@ -134,7 +133,7 @@ static void task_drain(struct bg_job *job, void *arg)
         /* Stop a runaway producer here rather than on the main thread's next poll, which may
          * be minutes away. Safe: the reap is gated on the EOF this thread has not set yet. */
         if (just_overflowed)
-            bash_signal_process_tree(t->pid, SIGKILL);
+            spawn_process_terminate(t->process, SIGKILL);
 
         /* write(2) outside the lock: the fd is drainer-owned for writing, and readers use
          * pread. Failure and progress land back under the lock. */
@@ -157,8 +156,8 @@ static void task_drain(struct bg_job *job, void *arg)
 /* Advance main-thread state: observe a shell exit, escalate an expired SIGTERM, and finish the
  * task. The task is done only when the exited shell's pipe also hit EOF, so group members that
  * outlive the shell (a slow TERM handler's children, orphans of a raced adoption) stay watched
- * and killable. Never signals after the reap — the pid may be recycled; deferring the reap
- * until EOF is what keeps the group signalable that long. */
+ * and killable. Never terminates after the consuming wait; deferring that wait until EOF keeps
+ * the owned process tree addressable for this whole transition. */
 static void task_poll(struct task *t)
 {
     long now = monotonic_ms();
@@ -166,17 +165,17 @@ static void task_poll(struct task *t)
     task_snapshot(t, &snap);
 
     if (!t->exit_seen) {
-        if (bash_process_exit_seen(t->pid, &t->exit_seen) < 0 && errno == ECHILD)
+        if (spawn_process_exit_seen(t->process, &t->exit_seen) < 0 && errno == ECHILD)
             t->exit_seen = 1;
         /* Orphans holding the pipe past the shell's exit are killed, matching the launch
          * path's policy; an armed TERM grace defers to the escalation instead. */
         if (t->exit_seen && !snap.eof && !t->kill_deadline_ms) {
-            bash_signal_process_tree(t->pid, SIGKILL);
+            spawn_process_terminate(t->process, SIGKILL);
             t->orphans_killed = 1;
         }
     }
     if (!t->done && t->kill_deadline_ms && now >= t->kill_deadline_ms) {
-        bash_signal_process_tree(t->pid, SIGKILL);
+        spawn_process_terminate(t->process, SIGKILL);
         t->kill_deadline_ms = 0;
     }
     if (t->drainer && snap.eof) {
@@ -191,14 +190,12 @@ static void task_poll(struct task *t)
         if (t->kill_deadline_ms)
             return;
         /* Anything still in the group closed its output and is untrackable; kill it while
-         * the unreaped zombie still reserves the group. Usually a no-op on the zombie. */
-        bash_signal_process_tree(t->pid, SIGKILL);
-        bash_shell_pgid_retract(t->pid);
-        int status = 0;
-        pid_t reaped;
-        while ((reaped = waitpid(t->pid, &status, 0)) < 0 && errno == EINTR)
-            ;
-        t->wait_status = reaped == t->pid ? status : 0;
+         * the process object still owns the tree. Usually a no-op on the exited root. */
+        spawn_process_terminate(t->process, SIGKILL);
+        bash_live_process_retract(t->process);
+        if (spawn_process_wait(t->process, &t->status) < 0)
+            t->status = (struct spawn_status){.end = SPAWN_END_FORCED};
+        t->process = NULL;
         t->done = 1;
         /* The reap may run long after the exit (the next prompt, minutes later); the
          * drainer's EOF stamp is the closest observation of the real finish. */
@@ -291,9 +288,9 @@ char *task_name_error(const char *name)
     return NULL;
 }
 
-const char *task_adopt(pid_t pid, int pipe_fd, const char *command, const char *name,
-                       long started_ms, int spool_fd, char *spool_path, size_t spooled_bytes,
-                       int binary, int pipe_eof)
+const char *task_adopt(struct spawn_process *process, int pipe_fd, const char *command,
+                       const char *name, long started_ms, int spool_fd, char *spool_path,
+                       size_t spooled_bytes, int binary, int pipe_eof)
 {
     /* The cap also keeps the fatal-cleanup pgid table from ever filling. */
     if (task_running_count() >= (size_t)config_int("task.max_running"))
@@ -306,7 +303,7 @@ const char *task_adopt(pid_t pid, int pipe_fd, const char *command, const char *
         snprintf(t->id, sizeof(t->id), "t%d", next_task_number);
     next_task_number++;
     t->command = xstrdup(command ? command : "");
-    t->pid = pid;
+    t->process = process;
     t->pipe_fd = pipe_fd;
     t->spool_fd = spool_fd;
     t->spool_path = spool_path;
@@ -317,10 +314,13 @@ const char *task_adopt(pid_t pid, int pipe_fd, const char *command, const char *
     t->eof = pipe_eof;
     pthread_mutex_init(&t->lock, NULL);
 
-    /* Task descriptors outlive this tool call, so later commands must not inherit them. */
+#ifndef _WIN32
+    /* Task descriptors outlive this tool call, so later commands must not inherit them. Windows
+     * creates both descriptors non-inheritable. */
     fcntl(pipe_fd, F_SETFD, FD_CLOEXEC);
     if (spool_fd >= 0)
         fcntl(spool_fd, F_SETFD, FD_CLOEXEC);
+#endif
 
     if (pipe_eof) {
         close(pipe_fd);
@@ -357,12 +357,12 @@ static void append_status_phrase(struct buf *out, struct task *t)
     char phrase[64];
     if (!t->done)
         snprintf(phrase, sizeof(phrase), "still running (%s)", elapsed);
-    else if (WIFSIGNALED(t->wait_status))
-        snprintf(phrase, sizeof(phrase), "killed (signal %d) after %s", WTERMSIG(t->wait_status),
-                 elapsed);
+    else if (t->status.end == SPAWN_END_SIGNALED)
+        snprintf(phrase, sizeof(phrase), "killed (signal %d) after %s", t->status.code, elapsed);
+    else if (t->status.end == SPAWN_END_FORCED)
+        snprintf(phrase, sizeof(phrase), "killed (forced) after %s", elapsed);
     else
-        snprintf(phrase, sizeof(phrase), "finished (exit %d) after %s",
-                 WIFEXITED(t->wait_status) ? WEXITSTATUS(t->wait_status) : -1, elapsed);
+        snprintf(phrase, sizeof(phrase), "finished (exit %d) after %s", t->status.code, elapsed);
     buf_append_str(out, phrase);
     if (t->orphans_killed)
         buf_append_str(out, "; orphaned processes killed");
@@ -590,13 +590,18 @@ static long deadline_after(long now_ms, long duration_ms)
  * or SIGKILL outright when the grace is zero. */
 static void signal_task_stop(struct task *t, long now)
 {
+#ifdef _WIN32
+    (void)now;
+    spawn_process_terminate(t->process, SIGKILL);
+#else
     long grace_ms = config_duration_ms("bash.timeout_grace");
     if (grace_ms > 0) {
-        bash_signal_process_tree(t->pid, SIGTERM);
+        spawn_process_terminate(t->process, SIGTERM);
         t->kill_deadline_ms = deadline_after(now, grace_ms);
     } else {
-        bash_signal_process_tree(t->pid, SIGKILL);
+        spawn_process_terminate(t->process, SIGKILL);
     }
+#endif
 }
 
 /* Forward the not-yet-displayed spooled bytes to the live display, exactly like a foreground
@@ -838,8 +843,9 @@ size_t task_list(struct task_info **rows_out)
         rows[i].command = t->command;
         rows[i].spool_path = snap.spool_write_failed ? NULL : t->spool_path;
         rows[i].running = !t->done;
-        rows[i].exit_code = t->done && WIFEXITED(t->wait_status) ? WEXITSTATUS(t->wait_status) : 0;
-        rows[i].term_signal = t->done && WIFSIGNALED(t->wait_status) ? WTERMSIG(t->wait_status) : 0;
+        rows[i].exit_code = t->done && t->status.end == SPAWN_END_EXITED ? t->status.code : 0;
+        rows[i].term_signal = t->done && t->status.end == SPAWN_END_SIGNALED ? t->status.code : 0;
+        rows[i].forced = t->done && t->status.end == SPAWN_END_FORCED;
         rows[i].elapsed_ms = (t->done ? t->finished_ms : monotonic_ms()) - t->started_ms;
         rows[i].total_bytes = snap.total_bytes;
         i++;
@@ -900,18 +906,19 @@ void task_registry_shutdown(void)
     while (tasks) {
         struct task *t = tasks;
         tasks = t->next;
-        /* Stop the drainer — the only other thread that may signal — before the reap makes
-         * signaling this pid unsafe. */
+        /* Stop the drainer — the only other thread that may terminate — before consuming the
+         * process object. */
         if (t->drainer) {
             bg_job_cancel(t->drainer);
             bg_job_join(t->drainer);
             t->drainer = NULL;
         }
         if (!t->done) {
-            bash_signal_process_tree(t->pid, SIGKILL);
-            bash_shell_pgid_retract(t->pid);
-            while (waitpid(t->pid, &t->wait_status, 0) < 0 && errno == EINTR)
-                ;
+            spawn_process_terminate(t->process, SIGKILL);
+            bash_live_process_retract(t->process);
+            if (spawn_process_wait(t->process, &t->status) < 0)
+                t->status = (struct spawn_status){.end = SPAWN_END_FORCED};
+            t->process = NULL;
             t->done = 1;
         }
         task_free(t);

--- a/src/tools/task_registry.h
+++ b/src/tools/task_registry.h
@@ -3,9 +3,10 @@
 #define HAX_TOOLS_TASK_REGISTRY_H
 
 #include <stddef.h>
-#include <sys/types.h>
 
 #include "tool.h"
+
+struct spawn_process;
 
 /* Process-local registry of background tasks: shell commands that outlived their foreground
  * window and keep running detached from the tool call that started them. Each task owns the
@@ -33,9 +34,9 @@ char *task_name_error(const char *name);
  * exited). Returns the registry-owned id after taking ownership of the process, pipe_fd,
  * spool_fd, and spool_path, or NULL when the drainer thread cannot start — the caller then
  * retains ownership of all of them and should fall back to killing the command. */
-const char *task_adopt(pid_t pid, int pipe_fd, const char *command, const char *name,
-                       long started_ms, int spool_fd, char *spool_path, size_t spooled_bytes,
-                       int binary, int pipe_eof);
+const char *task_adopt(struct spawn_process *process, int pipe_fd, const char *command,
+                       const char *name, long started_ms, int spool_fd, char *spool_path,
+                       size_t spooled_bytes, int binary, int pipe_eof);
 
 /* Return the bare output body produced since the last report (empty when there is none),
  * advancing the delivery cursor. *marker_out receives an owned withheld-content note (binary,
@@ -77,6 +78,7 @@ struct task_info {
     int running;
     int exit_code;   /* valid when !running and the command exited */
     int term_signal; /* signal that ended it; 0 otherwise */
+    int forced;      /* process tree was terminated by the platform backend */
     long elapsed_ms;
     size_t total_bytes;
 };

--- a/src/trace.c
+++ b/src/trace.c
@@ -68,7 +68,11 @@ void trace_init(void)
         hax_warn("HAX_TRACE: cannot open '%s' for writing", path);
         goto out_unlock;
     }
+#ifdef _WIN32
+    setvbuf(trace_fp, NULL, _IONBF, 0);
+#else
     setvbuf(trace_fp, NULL, _IOLBF, 0);
+#endif
     atexit(trace_close_atexit);
 
 out_unlock:

--- a/src/transcript.c
+++ b/src/transcript.c
@@ -577,7 +577,11 @@ struct transcript_log *transcript_log_open(const char *system_prompt, const stru
     }
 
     /* Make completed lines immediately visible to readers such as tail -f. */
+#ifdef _WIN32
+    setvbuf(stream, NULL, _IONBF, 0);
+#else
     setvbuf(stream, NULL, _IOLBF, 0);
+#endif
     struct transcript_log *log = xmalloc(sizeof(*log));
     log->stream = stream;
     log->path = xstrdup(path);
@@ -612,7 +616,11 @@ void transcript_log_reset(struct transcript_log *log, const char *system_prompt,
 
     log->stream = stream;
     /* Stream buffering does not portably survive freopen. */
+#ifdef _WIN32
+    setvbuf(stream, NULL, _IONBF, 0);
+#else
     setvbuf(stream, NULL, _IOLBF, 0);
+#endif
     log->items_written = 0;
     log->turn_number = 0;
     transcript_render_header(stream, TRANSCRIPT_RENDER_PLAIN, system_prompt, tools, n_tools);

--- a/src/util.c
+++ b/src/util.c
@@ -27,12 +27,20 @@ void locale_init_utf8(void)
     locale_is_utf8 = 0;
     locale_children_are_utf8 = 0;
 
+#ifdef _WIN32
+    if (setlocale(LC_CTYPE, ".UTF8")) {
+        locale_is_utf8 = 1;
+        locale_children_are_utf8 = 1;
+        return;
+    }
+#else
     setlocale(LC_CTYPE, "");
     if (strcmp(nl_langinfo(CODESET), "UTF-8") == 0) {
         locale_is_utf8 = 1;
         locale_children_are_utf8 = 1;
         return;
     }
+#endif
     /* OpenBSD ships no default locale at all, yet renders UTF-8 whatever the locale claims. This
      * process needs one regardless of the environment: mbrtowc() decodes the model's text here, and
      * without it every multibyte character is measured as its separate bytes.
@@ -40,7 +48,16 @@ void locale_init_utf8(void)
      * The spellings are PEP 538's, there being no portable one: glibc and the BSDs answer to
      * C.UTF-8, macOS only to a bare UTF-8. A language-bearing name is the last resort, for systems
      * where only specific locales were generated. */
-    static const char *const CANDIDATES[] = {"C.UTF-8", "C.utf8", "UTF-8", "en_US.UTF-8"};
+    static const char *const CANDIDATES[] = {
+#ifdef _WIN32
+        ".UTF8",
+#else
+        "C.UTF-8",
+        "C.utf8",
+        "UTF-8",
+        "en_US.UTF-8",
+#endif
+    };
     const char *chosen = NULL;
     for (size_t i = 0; !chosen && i < sizeof(CANDIDATES) / sizeof(CANDIDATES[0]); i++)
         chosen = setlocale(LC_CTYPE, CANDIDATES[i]);
@@ -226,6 +243,12 @@ char *shell_single_quote(const char *str)
 void gen_uuid_v4(char out[37])
 {
     uint8_t bytes[16];
+#ifdef _WIN32
+    if (BCryptGenRandom(NULL, bytes, sizeof(bytes), BCRYPT_USE_SYSTEM_PREFERRED_RNG) != 0) {
+        hax_err("BCryptGenRandom failed");
+        abort();
+    }
+#else
     int fd = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
     if (fd < 0) {
         hax_err("open /dev/urandom: %s", strerror(errno));
@@ -248,6 +271,7 @@ void gen_uuid_v4(char out[37])
         bytes_read += (size_t)count;
     }
     close(fd);
+#endif
 
     bytes[6] = (bytes[6] & 0x0f) | 0x40; /* RFC 4122 version 4 */
     bytes[8] = (bytes[8] & 0x3f) | 0x80; /* RFC 4122 variant */

--- a/subprojects/.gitignore
+++ b/subprojects/.gitignore
@@ -1,0 +1,2 @@
+/curl-*/
+/jansson-*/

--- a/subprojects/curl.wrap
+++ b/subprojects/curl.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = curl-8.12.1
+source_url = https://github.com/curl/curl/releases/download/curl-8_12_1/curl-8.12.1.tar.xz
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/curl_8.12.1-2/get_source/curl-8.12.1.tar.xz
+source_filename = curl-8.12.1.tar.xz
+source_hash = 0341f1ed97a26c811abaebd37d62b833956792b7607ea3f15d001613c76de202
+patch_filename = curl_8.12.1-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/curl_8.12.1-2/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/curl_8.12.1-2/curl_8.12.1-2_patch.zip
+patch_hash = bfd8886cc76ccfab52b1b0472e6c682cdf5374a4c30be2427326f2f495de4eba
+wrapdb_version = 8.12.1-2
+
+[provide]
+dependency_names = libcurl

--- a/subprojects/jansson.wrap
+++ b/subprojects/jansson.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = jansson-2.14.1
+source_url = https://github.com/akheron/jansson/releases/download/v2.14.1/jansson-2.14.1.tar.bz2
+source_filename = jansson-2.14.1.tar.bz2
+source_hash = 6bd82d3043dadbcd58daaf903d974891128d22aab7dada5d399cb39094af49ce
+patch_filename = jansson_2.14.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/jansson_2.14.1-1/get_patch
+patch_hash = 0dd14ac359a96b5d1c17b701cda70ba530de38c078e11cf6691aa4ae6978791d
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/jansson_2.14.1-1/jansson-2.14.1.tar.bz2
+wrapdb_version = 2.14.1-1
+
+[provide]
+jansson = jansson_dep

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -51,7 +51,9 @@ def hermetic_env(home: Path) -> dict[str, str]:
     return env
 
 
-def run_oneshot(prompt: str, mock_script: str) -> Result:
+def run_oneshot(
+    prompt: str, mock_script: str, env_overrides: dict[str, str] | None = None
+) -> Result:
     """Run `hax -p <prompt>` against scripts/mock/<mock_script> in a scratch cwd."""
     home = scratch_dir()
     workdir = home / "work"
@@ -59,6 +61,8 @@ def run_oneshot(prompt: str, mock_script: str) -> Result:
     env = hermetic_env(home)
     env["HAX_PROVIDER"] = "mock"
     env["HAX_MOCK_SCRIPT"] = str(REPO_ROOT / "scripts" / "mock" / mock_script)
+    if env_overrides:
+        env.update(env_overrides)
     # Resolve before the cwd switch so a relative HAX_BIN keeps meaning what
     # the caller wrote; decode as UTF-8 regardless of the host locale.
     binary = Path(os.environ.get("HAX_BIN", str(REPO_ROOT / "build" / "hax"))).resolve()

--- a/tests/e2e/test_logging.py
+++ b/tests/e2e/test_logging.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Trace and transcript destinations are created and populated in one-shot mode."""
+
+import harness
+
+
+for variable, filename in (
+    ("HAX_TRACE", "trace.log"),
+    ("HAX_TRANSCRIPT", "transcript.log"),
+):
+    result = harness.run_oneshot("hi", "hello.txt", {variable: filename})
+    harness.expect(result.returncode == 0, f"{variable} run exits 0", result)
+    path = result.workdir / filename
+    harness.expect(path.is_file(), f"{variable} creates its destination", result)
+    if variable == "HAX_TRANSCRIPT":
+        harness.expect("hi" in path.read_text(encoding="utf-8"), "transcript records prompt", result)

--- a/tests/harness.h
+++ b/tests/harness.h
@@ -78,7 +78,7 @@ static int t_skips = 0;
 static char **t_tmpdirs;
 static size_t t_n_tmpdirs;
 static size_t t_tmpdir_first; /* first entry owned by this process */
-static pid_t t_tmpdir_owner;
+static int t_tmpdir_owner;
 
 static inline void t_tempdir_cleanup(void)
 {

--- a/tests/harness.h
+++ b/tests/harness.h
@@ -8,6 +8,10 @@
 #include <string.h>
 #include <unistd.h>
 
+#ifdef _WIN32
+#include "system/spawn.h"
+#endif
+
 /* Sanitizer detection, for tests that must widen or skip timing-sensitive
  * checks that sanitizer interceptors (notably fork) slow by orders of
  * magnitude. Clang reports via __has_feature, gcc via __SANITIZE_*__. */
@@ -95,7 +99,11 @@ static inline void t_tempdir_cleanup(void)
                      "/usr/bin/find '%s' -type d -exec /bin/chmod u+rwx {} \\; 2>/dev/null; "
                      "/bin/rm -rf '%s'",
                      t_tmpdirs[i], t_tmpdirs[i]);
+#ifdef _WIN32
+            if (spawn_shell_wait(cmd) != 0)
+#else
             if (system(cmd) != 0)
+#endif
                 fprintf(stderr, "t_tempdir: failed to remove %s\n", t_tmpdirs[i]);
         }
         /* Inherited copies are freed only here, at exit — mid-run they
@@ -127,7 +135,19 @@ static inline char *t_tempdir(void)
         t_tmpdir_owner = getpid();
         atexit(t_tempdir_cleanup);
     }
+#ifdef _WIN32
+    const char *temporary = getenv("TMPDIR");
+    if (!temporary || !*temporary)
+        temporary = getenv("TEMP");
+    if (!temporary || !*temporary)
+        temporary = ".";
+    size_t template_length = strlen(temporary) + strlen("/hax_test_XXXXXX") + 1;
+    char *dir = malloc(template_length);
+    if (dir)
+        snprintf(dir, template_length, "%s/hax_test_XXXXXX", temporary);
+#else
     char *dir = strdup("/tmp/hax_test_XXXXXX");
+#endif
     if (!dir || !mkdtemp(dir)) {
         fprintf(stderr, "t_tempdir: %s\n", strerror(errno));
         abort();

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -123,18 +123,12 @@ windows_incompatible_tests = [
     'test_cli.c',
     'test_compact.c',
     'test_config.c',
-    'test_cred_store.c',
     'test_file_mention.c',
     'test_paste_image.c',
-    'test_session.c',
-    'test_session_prune.c',
-    'test_trace.c',
     'test_util.c',
     'render/test_spinner.c',
     'system/test_fs.c',
     'system/test_git.c',
-    'system/test_os.c',
-    'system/test_tempfiles.c',
     'tools/test_bash.c',
     'tools/test_edit.c',
     'tools/test_read.c',
@@ -177,6 +171,7 @@ endforeach
 # e2e/test_oneshot_text.py registers as e2e/oneshot_text, so the name prefix
 # selects the group (`meson test 'e2e/*'`).
 e2e_scenarios = [
+    'logging',
     'oneshot_text',
     'oneshot_tool',
 ]

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -19,7 +19,6 @@ test_sources = [
     'test_agent_usage.c',
     'test_banner.c',
     'test_catalog.c',
-    'test_catalog_fetch.c',
     'test_cli.c',
     'test_compact.c',
     'test_config.c',
@@ -29,7 +28,6 @@ test_sources = [
     'test_history.c',
     'test_model_meta.c',
     'test_model_sort.c',
-    'test_harness.c',
     'test_oneshot.c',
     'test_paste_image.c',
     'test_provider.c',
@@ -46,7 +44,6 @@ test_sources = [
 
     'providers/test_anthropic_body.c',
     'providers/test_anthropic_events.c',
-    'providers/test_anthropic_models.c',
     'providers/test_chat_body.c',
     'providers/test_chat_events.c',
     'providers/test_codex.c',
@@ -54,7 +51,6 @@ test_sources = [
     'providers/test_codex_login.c',
     'providers/test_codex_settings.c',
     'providers/test_config_provider.c',
-    'providers/test_http_provider.c',
     'providers/test_llamacpp.c',
     'providers/test_mock.c',
     'providers/test_model_info.c',
@@ -63,7 +59,6 @@ test_sources = [
     'providers/test_registry.c',
     'providers/test_responses_body.c',
     'providers/test_responses_events.c',
-    'providers/test_stream_retry.c',
     'providers/test_wire.c',
 
     'render/test_ctrl_strip.c',
@@ -83,7 +78,6 @@ test_sources = [
     'system/test_keepawake.c',
     'system/test_os.c',
     'system/test_path.c',
-    'system/test_spawn.c',
     'system/test_tempfiles.c',
 
     'terminal/test_clipboard.c',
@@ -115,13 +109,59 @@ test_sources = [
 
     'transport/test_api_error.c',
     'transport/test_ca.c',
-    'transport/test_http.c',
     'transport/test_retry.c',
     'transport/test_sse.c',
 ]
 
+# These fixtures are small POSIX socket servers. Windows exercises the same HTTP paths through
+# one-shot end-to-end tests instead of carrying a second test-server implementation.
+windows_incompatible_tests = [
+    'test_agent.c',
+    'test_agent_core.c',
+    'test_agent_env.c',
+    'test_agent_loop.c',
+    'test_cli.c',
+    'test_compact.c',
+    'test_config.c',
+    'test_cred_store.c',
+    'test_file_mention.c',
+    'test_paste_image.c',
+    'test_session.c',
+    'test_session_prune.c',
+    'test_trace.c',
+    'test_util.c',
+    'render/test_spinner.c',
+    'system/test_fs.c',
+    'system/test_git.c',
+    'system/test_os.c',
+    'system/test_tempfiles.c',
+    'tools/test_bash.c',
+    'tools/test_edit.c',
+    'tools/test_read.c',
+    'tools/test_task.c',
+    'tools/test_task_wait.c',
+    'tools/test_write.c',
+]
+
+if host_machine.system() == 'windows'
+    test_sources += ['system/test_windows.c']
+else
+    test_sources += [
+        'test_catalog_fetch.c',
+        'test_harness.c',
+        'system/test_spawn.c',
+        'providers/test_anthropic_models.c',
+        'providers/test_http_provider.c',
+        'providers/test_stream_retry.c',
+        'transport/test_http.c',
+    ]
+endif
+
 fs = import('fs')
 foreach src : test_sources
+    if host_machine.system() == 'windows' and src in windows_incompatible_tests
+        continue
+    endif
     stem = fs.stem(src).substring(5)  # drop the leading 'test_'
     parent = fs.parent(src)
     name = parent == '.' ? stem : parent / stem

--- a/tests/system/test_keepawake.c
+++ b/tests/system/test_keepawake.c
@@ -15,10 +15,12 @@
 
 static void expect_no_children(void)
 {
+#ifndef _WIN32
     int status;
     errno = 0;
     pid_t child = waitpid(-1, &status, WNOHANG);
     EXPECT(child == -1 && errno == ECHILD);
+#endif
 }
 
 static void test_release_without_acquire(void)
@@ -51,6 +53,7 @@ static void test_disabled_is_noop(void)
     config_set_override("keep_awake", "1");
 }
 
+#ifndef _WIN32
 static void test_sleep_not_resolved_via_path(void)
 {
     char *dir = t_tempdir();
@@ -95,6 +98,7 @@ out:
     free(marker);
     free(fake_sleep);
 }
+#endif
 
 int main(void)
 {
@@ -103,6 +107,8 @@ int main(void)
     test_acquire_release_cycle();
     test_double_acquire();
     test_disabled_is_noop();
+#ifndef _WIN32
     test_sleep_not_resolved_via_path();
+#endif
     T_REPORT();
 }

--- a/tests/system/test_path.c
+++ b/tests/system/test_path.c
@@ -306,6 +306,27 @@ static void test_path_relativize_accepts_dots_within_component(void)
     free(relative);
 }
 
+static void test_path_normalize_windows_drive(void)
+{
+    char *normalized = path_normalize_windows("C:\\Users\\alice\\repo");
+    EXPECT_STR_EQ(normalized, "/c/Users/alice/repo");
+    free(normalized);
+}
+
+static void test_path_normalize_windows_unc(void)
+{
+    char *normalized = path_normalize_windows("\\\\server\\share\\repo");
+    EXPECT_STR_EQ(normalized, "//server/share/repo");
+    free(normalized);
+}
+
+static void test_path_normalize_windows_relative(void)
+{
+    char *normalized = path_normalize_windows("src\\main.c");
+    EXPECT_STR_EQ(normalized, "src/main.c");
+    free(normalized);
+}
+
 int main(void)
 {
     test_path_join_simple();
@@ -355,6 +376,10 @@ int main(void)
     test_path_relativize_rejects_non_escaping_parent_component();
     test_path_relativize_rejects_trailing_parent_component();
     test_path_relativize_accepts_dots_within_component();
+
+    test_path_normalize_windows_drive();
+    test_path_normalize_windows_unc();
+    test_path_normalize_windows_relative();
 
     T_REPORT();
 }

--- a/tests/system/test_tempfiles.c
+++ b/tests/system/test_tempfiles.c
@@ -47,8 +47,13 @@ static void test_create_tracks_files_and_cleanup_removes_them(void)
     EXPECT_STR_EQ(plain_dir, image_dir);
 
     struct stat st;
+#ifdef _WIN32
+    EXPECT(stat(plain_dir, &st) == 0);
+    EXPECT(stat(plain_path, &st) == 0);
+#else
     EXPECT(stat(plain_dir, &st) == 0 && (st.st_mode & 0777) == 0700);
     EXPECT(stat(plain_path, &st) == 0 && (st.st_mode & 0777) == 0600);
+#endif
     EXPECT(write(plain_fd, "x", 1) == 1);
     close(plain_fd);
     close(image_fd);

--- a/tests/system/test_windows.c
+++ b/tests/system/test_windows.c
@@ -1,15 +1,23 @@
 /* SPDX-License-Identifier: MIT */
 #ifdef _WIN32
 
+#include <aclapi.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <io.h>
 #include <stdlib.h>
 #include <string.h>
+#include <windows.h>
 #include <curl/curl.h>
 #include <sys/file.h>
 
+#include "config.h"
 #include "harness.h"
 #include "session.h"
+#include "tool.h"
 #include "system/path.h"
 #include "system/spawn.h"
+#include "tools/task_registry.h"
 
 static void test_curl_uses_schannel(void)
 {
@@ -66,6 +74,132 @@ static void test_advisory_file_lock(void)
     unlink(path);
 }
 
+static void test_stdio_mode_extensions(void)
+{
+    char path[] = "hax_stdio_XXXXXX";
+    int fd = mkstemp(path);
+    EXPECT(fd >= 0);
+    if (fd >= 0)
+        close(fd);
+
+    FILE *file = fopen(path, "we");
+    EXPECT(file != NULL);
+    if (file) {
+        EXPECT(fputs("logged", file) >= 0);
+        EXPECT(fclose(file) == 0);
+    }
+    size_t length = 0;
+    char *content = slurp_file(path, &length);
+    EXPECT(content != NULL && length == 6);
+    EXPECT(content && memcmp(content, "logged", 6) == 0);
+    free(content);
+    unlink(path);
+}
+
+static void test_positional_read_preserves_offset(void)
+{
+    char path[] = "hax_pread_XXXXXX";
+    int fd = mkstemp(path);
+    EXPECT(fd >= 0);
+    if (fd < 0)
+        return;
+    EXPECT(write(fd, "0123456789", 10) == 10);
+    EXPECT(lseek(fd, 3, SEEK_SET) == 3);
+    char bytes[3] = {0};
+    EXPECT(pread(fd, bytes, 2, 7) == 2);
+    EXPECT(memcmp(bytes, "78", 2) == 0);
+    EXPECT(lseek(fd, 0, SEEK_CUR) == 3);
+    close(fd);
+    unlink(path);
+}
+
+static void test_open_guarantees(void)
+{
+    char path[] = "hax_open_XXXXXX";
+    int fd = mkstemp(path);
+    EXPECT(fd >= 0);
+    if (fd >= 0) {
+        DWORD flags = HANDLE_FLAG_INHERIT;
+        HANDLE handle = (HANDLE)_get_osfhandle(fd);
+        EXPECT(GetHandleInformation(handle, &flags));
+        EXPECT(!(flags & HANDLE_FLAG_INHERIT));
+        errno = 0;
+        EXPECT(fchmod(fd, 0644) < 0 && errno == ENOTSUP);
+        close(fd);
+    }
+
+    errno = 0;
+    fd = open(path, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    EXPECT(fd < 0 && errno == ENOTDIR);
+    fd = open(t_tempdir(), O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    EXPECT(fd >= 0);
+    if (fd >= 0)
+        close(fd);
+
+    errno = 0;
+    fd = open("NUL", O_WRONLY | O_NONBLOCK | O_CLOEXEC);
+    EXPECT(fd < 0);
+
+    char *link_path = xasprintf("%s-link", path);
+    if (symlink(path, link_path) == 0) {
+        errno = 0;
+        fd = open(link_path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC);
+        EXPECT(fd < 0 && errno == ELOOP);
+        unlink(link_path);
+    }
+    free(link_path);
+    unlink(path);
+}
+
+static void test_private_file_acl(void)
+{
+    char path[] = "hax_acl_XXXXXX";
+    int fd = mkstemp(path);
+    EXPECT(fd >= 0);
+    if (fd < 0)
+        return;
+    HANDLE handle = (HANDLE)_get_osfhandle(fd);
+    PSID owner = NULL;
+    PACL acl = NULL;
+    PSECURITY_DESCRIPTOR descriptor = NULL;
+    DWORD result = GetSecurityInfo(handle, SE_FILE_OBJECT,
+                                   OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION, &owner,
+                                   NULL, &acl, NULL, &descriptor);
+    EXPECT(result == ERROR_SUCCESS);
+    ACL_SIZE_INFORMATION info = {0};
+    EXPECT(result != ERROR_SUCCESS ||
+           GetAclInformation(acl, &info, sizeof(info), AclSizeInformation));
+    EXPECT(result != ERROR_SUCCESS || info.AceCount == 1);
+    if (result == ERROR_SUCCESS && info.AceCount == 1) {
+        ACCESS_ALLOWED_ACE *ace = NULL;
+        EXPECT(GetAce(acl, 0, (void **)&ace));
+        EXPECT(ace && EqualSid(owner, &ace->SidStart));
+    }
+    LocalFree(descriptor);
+    close(fd);
+    unlink(path);
+}
+
+static void test_background_output_stream(void)
+{
+    config_set_override("bash.background_yield", "1ms");
+    char *launch =
+        TOOL_BASH.run("{\"command\":\"for i in $(seq 1 1000); do printf '%04d\\\\n' \\\"$i\\\"; "
+                      "done; sleep 0.2\",\"background\":true,\"name\":\"win-race\"}",
+                      NULL);
+    EXPECT(launch != NULL && strstr(launch, "task win-race") != NULL);
+    char *result = task_wait_stream("win-race", 30000, 0, NULL, NULL);
+    EXPECT(result != NULL);
+    char *combined = xasprintf("%s%s", launch ? launch : "", result ? result : "");
+    EXPECT(strstr(combined, "0001\n") != NULL);
+    EXPECT(strstr(combined, "1000\n") != NULL);
+    EXPECT(strstr(combined, "finished (exit 0)") != NULL);
+    free(combined);
+    free(launch);
+    free(result);
+    task_registry_shutdown();
+}
+
 static void test_session_materialization(void)
 {
     setenv("XDG_STATE_HOME", t_tempdir(), 1);
@@ -91,6 +225,11 @@ int main(void)
     test_native_capture();
     test_canonical_cwd();
     test_advisory_file_lock();
+    test_stdio_mode_extensions();
+    test_positional_read_preserves_offset();
+    test_open_guarantees();
+    test_private_file_acl();
+    test_background_output_stream();
     test_session_materialization();
     T_REPORT();
 }

--- a/tests/system/test_windows.c
+++ b/tests/system/test_windows.c
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: MIT */
+#ifdef _WIN32
+
+#include <stdlib.h>
+#include <string.h>
+#include <curl/curl.h>
+#include <sys/file.h>
+
+#include "harness.h"
+#include "session.h"
+#include "system/path.h"
+#include "system/spawn.h"
+
+static void test_curl_uses_schannel(void)
+{
+    const curl_version_info_data *version = curl_version_info(CURLVERSION_NOW);
+    EXPECT(version != NULL);
+    EXPECT(version && version->ssl_version && strstr(version->ssl_version, "Schannel") != NULL);
+    EXPECT(version && (!version->ssl_version || strstr(version->ssl_version, "OpenSSL") == NULL));
+}
+
+static void test_git_bash_validation(void)
+{
+    EXPECT(spawn_win32_bash_available());
+}
+
+static void test_native_capture(void)
+{
+    const char *const argv[] = {"git.exe", "--version", NULL};
+    size_t length = 0;
+    char *output = spawn_capture_stdout(argv, 1024, 3000, &length);
+    EXPECT(output != NULL);
+    EXPECT(output && length > 4 && strncmp(output, "git version ", 12) == 0);
+    free(output);
+}
+
+static void test_canonical_cwd(void)
+{
+    char *cwd = getcwd(NULL, 0);
+    EXPECT(cwd != NULL);
+    EXPECT(cwd && cwd[0] == '/' && cwd[2] == '/');
+    free(cwd);
+}
+
+static void test_advisory_file_lock(void)
+{
+    char path[] = "hax_lock_XXXXXX";
+    int first = mkstemp(path);
+    int second = open(path, O_RDWR);
+    EXPECT(first >= 0);
+    EXPECT(second >= 0);
+    if (first >= 0) {
+        EXPECT(flock(first, LOCK_SH) == 0);
+        EXPECT(write(first, "x", 1) == 1);
+    }
+    if (second >= 0) {
+        EXPECT(flock(second, LOCK_EX | LOCK_NB) < 0);
+        if (first >= 0)
+            EXPECT(flock(first, LOCK_UN) == 0);
+        EXPECT(flock(second, LOCK_EX | LOCK_NB) == 0);
+        EXPECT(flock(second, LOCK_UN) == 0);
+        close(second);
+    }
+    if (first >= 0)
+        close(first);
+    unlink(path);
+}
+
+static void test_session_materialization(void)
+{
+    setenv("XDG_STATE_HOME", t_tempdir(), 1);
+    unsetenv("HAX_NO_SESSION");
+    struct session_log *log = session_log_open("mock", "mock-model", NULL, NULL, NULL);
+    EXPECT(log != NULL);
+    if (!log)
+        return;
+
+    struct item items[] = {{.kind = ITEM_TURN_BOUNDARY},
+                           {.kind = ITEM_USER_MESSAGE, .text = (char *)"ping"}};
+    session_log_append(log, items, sizeof(items) / sizeof(*items));
+    EXPECT(session_log_materialized(log));
+    const char *path = session_log_path(log);
+    EXPECT(path != NULL && access(path, F_OK) == 0);
+    session_log_close(log);
+}
+
+int main(void)
+{
+    test_curl_uses_schannel();
+    test_git_bash_validation();
+    test_native_capture();
+    test_canonical_cwd();
+    test_advisory_file_lock();
+    test_session_materialization();
+    T_REPORT();
+}
+
+#endif /* _WIN32 */

--- a/tests/test_cred_store.c
+++ b/tests/test_cred_store.c
@@ -56,7 +56,9 @@ static void test_store_mode_0600(void)
     if (path) {
         struct stat file_stat;
         EXPECT(stat(path, &file_stat) == 0);
+#ifndef _WIN32
         EXPECT((file_stat.st_mode & 0777) == 0600);
+#endif
         free(path);
     }
 }

--- a/tests/test_session.c
+++ b/tests/test_session.c
@@ -338,7 +338,9 @@ static void test_session_file_permissions(void)
 
     struct stat st;
     EXPECT(stat(path, &st) == 0);
+#ifndef _WIN32
     EXPECT((st.st_mode & 0077) == 0);
+#endif
 
     free(path);
 }
@@ -767,6 +769,7 @@ static void test_read_meta_failure_initializes_output(void)
     EXPECT(meta.provider == NULL && meta.id == NULL);
 }
 
+#ifndef _WIN32
 static void test_session_readers_reject_fifo(void)
 {
     char *path = xasprintf("%s/session.jsonl", t_tempdir());
@@ -785,6 +788,7 @@ static void test_session_readers_reject_fifo(void)
     unlink(path);
     free(path);
 }
+#endif
 
 static void test_load_enforces_image_count_cap(void)
 {
@@ -883,7 +887,9 @@ int main(void)
     test_discarded_selection_stays_out_of_log();
     test_truncate_restates_live_selection();
     test_read_meta_failure_initializes_output();
+#ifndef _WIN32
     test_session_readers_reject_fifo();
+#endif
     test_load_enforces_image_count_cap();
     test_load_budgets_images_from_compaction_seed();
     T_REPORT();


### PR DESCRIPTION
Quick demo:
https://github.com/user-attachments/assets/354ac565-d4d0-4569-8ae3-6630ab384d14

More of an POC/RFC to gauge interest than something to merge as-is. I tried to isolate Windows-specific code as much as possible. You get a statically-linked `hax.exe` of ~1.2mb that works in Windows Terminal as well as VSCode/Zed/Git Bash. It does this by enabling UTF-8/VT mode from Windows 10+, so the terminal handling can be uniform. Bash is found through Git on the path.

Things could probably be cleaned up by switching to libuv or a combination of libraries for cross-platform subprocess/filesystem/pipes/threads/timers/TTY to introduce a proper abstraction. Another possible approach is to use cosmopolitan/MSYS/cygwin, but I'm not a huge fan because they just pretend Windows is Linux...