### PR TITLE
Surface routed-provider failures on Chat Completions streams as errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ notes (see [docs/releasing.md](docs/releasing.md)).
 
 ## [Unreleased]
 
+### Fixed
+
+- Chat Completions streams now surface upstream failures reported via OpenRouter's
+  `native_finish_reason` (`network_error`, `error`) or the normalized finish reason `error` as
+  errors instead of rendering an empty response, and an upstream failure takes precedence over a
+  simultaneous truncation reason. Other native stop reasons still behave as normal completions.
+
 ## [0.4.0] - 2026-08-22
 
 ### Added

--- a/src/providers/chat_events.c
+++ b/src/providers/chat_events.c
@@ -385,7 +385,18 @@ static void emit_terminal_event(struct chat_events *parser)
     emit_event(parser, &event);
 }
 
-static void handle_finish_reason(struct chat_events *parser, const char *reason)
+/* OpenRouter reports the upstream's own stop reason beside finish_reason, and a routed provider
+ * failure arrives as HTTP 200 with empty content, finish_reason "stop", and one of these
+ * sentinels. Other passthrough values ("end_turn", "stop_sequence", ...) are normal stops.
+ * Failures can also arrive as the normalized finish_reason "error" with no native detail. */
+static int native_finish_is_error(const char *native_reason)
+{
+    return native_reason &&
+           (strcmp(native_reason, "network_error") == 0 || strcmp(native_reason, "error") == 0);
+}
+
+static void handle_finish_reason(struct chat_events *parser, const char *reason,
+                                 const char *native_reason)
 {
     if (parser->terminal_emitted || parser->finish_received)
         return;
@@ -394,14 +405,19 @@ static void handle_finish_reason(struct chat_events *parser, const char *reason)
     finish_tool_calls(parser);
     parser->finish_received = 1;
 
+    int upstream_error =
+        native_finish_is_error(native_reason) || (reason && strcmp(reason, "error") == 0);
     int truncated =
         reason && (strcmp(reason, "length") == 0 || strcmp(reason, "content_filter") == 0);
-    if (!truncated) {
+    if (!truncated && !upstream_error) {
         parser->finish_reason = xstrdup(reason ? reason : "stop");
         return;
     }
 
-    if (strcmp(reason, "length") == 0 && parser->length_hint)
+    if (upstream_error)
+        parser->finish_error =
+            xasprintf("upstream error: %s", native_reason ? native_reason : reason);
+    else if (strcmp(reason, "length") == 0 && parser->length_hint)
         parser->finish_error = xasprintf("response incomplete: length — %s", parser->length_hint);
     else
         parser->finish_error = xasprintf("response incomplete: %s", reason);
@@ -461,8 +477,10 @@ static void handle_choice_delta(struct chat_events *parser, json_t *choice)
     }
 
     const char *finish_reason = json_string_value(json_object_get(choice, "finish_reason"));
-    if (finish_reason)
-        handle_finish_reason(parser, finish_reason);
+    const char *native_reason = json_string_value(json_object_get(choice, "native_finish_reason"));
+    /* A benign native reason alone is not a finish. */
+    if (finish_reason || native_finish_is_error(native_reason))
+        handle_finish_reason(parser, finish_reason, native_reason);
 }
 
 void chat_events_feed(struct chat_events *parser, const char *data)

--- a/tests/providers/test_chat_events.c
+++ b/tests/providers/test_chat_events.c
@@ -134,11 +134,29 @@ static void feed_content(struct chat_events *parser, const char *text)
     chat_events_feed(parser, data);
 }
 
+static void feed_finish_native(struct chat_events *parser, const char *reason,
+                               const char *native_reason)
+{
+    char reason_json[64];
+    if (reason)
+        snprintf(reason_json, sizeof(reason_json), "\"%s\"", reason);
+    else
+        snprintf(reason_json, sizeof(reason_json), "null");
+    char data[512];
+    if (native_reason)
+        snprintf(data, sizeof(data),
+                 "{\"choices\":[{\"delta\":{},\"finish_reason\":%s,"
+                 "\"native_finish_reason\":\"%s\"}]}",
+                 reason_json, native_reason);
+    else
+        snprintf(data, sizeof(data), "{\"choices\":[{\"delta\":{},\"finish_reason\":%s}]}",
+                 reason_json);
+    chat_events_feed(parser, data);
+}
+
 static void feed_finish(struct chat_events *parser, const char *reason)
 {
-    char data[512];
-    snprintf(data, sizeof(data), "{\"choices\":[{\"delta\":{},\"finish_reason\":\"%s\"}]}", reason);
-    chat_events_feed(parser, data);
+    feed_finish_native(parser, reason, NULL);
 }
 
 static void test_text_delta(void)
@@ -516,6 +534,120 @@ static void test_finish_reason_content_filter_emits_error(void)
     EVENTS_FIXTURE_FREE(capture, parser);
 }
 
+static void test_native_finish_error_emits_error(void)
+{
+    EVENTS_FIXTURE(capture, parser);
+    /* OpenRouter's routed-provider failure shape: HTTP 200, empty content, stop + sentinel. */
+    chat_events_feed(&parser, "{\"choices\":[{\"delta\":{\"content\":\"\"},"
+                              "\"finish_reason\":\"stop\","
+                              "\"native_finish_reason\":\"network_error\"}]}");
+    EXPECT(capture.n_events == 0);
+    chat_events_feed(&parser, "[DONE]");
+    EXPECT(capture.n_events == 1);
+    EXPECT(capture.events[0].kind == EV_ERROR);
+    EXPECT(strstr(capture.events[0].message, "network_error") != NULL);
+    EXPECT(parser.terminal_emitted == 1);
+    EVENTS_FIXTURE_FREE(capture, parser);
+}
+
+static void test_native_finish_benign_passthrough_keeps_done(void)
+{
+    EVENTS_FIXTURE(capture, parser);
+    feed_finish_native(&parser, "stop", "end_turn");
+    chat_events_feed(&parser, "[DONE]");
+    EXPECT(capture.n_events == 1);
+    EXPECT(capture.events[0].kind == EV_DONE);
+    EXPECT_STR_EQ(capture.events[0].message, "stop");
+    EVENTS_FIXTURE_FREE(capture, parser);
+}
+
+static void test_native_finish_error_without_reason_emits_error(void)
+{
+    EVENTS_FIXTURE(capture, parser);
+    feed_finish_native(&parser, NULL, "error");
+    chat_events_feed(&parser, "[DONE]");
+    EXPECT(capture.n_events == 1);
+    EXPECT(capture.events[0].kind == EV_ERROR);
+    EXPECT(strstr(capture.events[0].message, "error") != NULL);
+    EVENTS_FIXTURE_FREE(capture, parser);
+}
+
+static void test_native_finish_benign_with_tool_calls_keeps_done(void)
+{
+    EVENTS_FIXTURE(capture, parser);
+    feed_finish_native(&parser, "tool_calls", "end_turn");
+    chat_events_feed(&parser, "[DONE]");
+    EXPECT(capture.n_events == 1);
+    EXPECT(capture.events[0].kind == EV_DONE);
+    EXPECT_STR_EQ(capture.events[0].message, "tool_calls");
+    EVENTS_FIXTURE_FREE(capture, parser);
+}
+
+static void test_finish_reason_error_emits_error(void)
+{
+    EVENTS_FIXTURE(capture, parser);
+    feed_finish(&parser, "error");
+    chat_events_feed(&parser, "[DONE]");
+    EXPECT(capture.n_events == 1);
+    EXPECT(capture.events[0].kind == EV_ERROR);
+    EXPECT(strstr(capture.events[0].message, "error") != NULL);
+    EVENTS_FIXTURE_FREE(capture, parser);
+}
+
+static void test_native_error_dominates_truncation(void)
+{
+    EVENTS_FIXTURE(capture, parser);
+    feed_finish_native(&parser, "length", "network_error");
+    chat_events_feed(&parser, "[DONE]");
+    EXPECT(capture.n_events == 1);
+    EXPECT(capture.events[0].kind == EV_ERROR);
+    EXPECT(strstr(capture.events[0].message, "upstream error: network_error") != NULL);
+    EVENTS_FIXTURE_FREE(capture, parser);
+}
+
+static void test_native_finish_benign_without_reason_is_not_a_finish(void)
+{
+    EVENTS_FIXTURE(capture, parser);
+    feed_finish_native(&parser, NULL, "end_turn");
+    chat_events_finalize(&parser);
+    EXPECT(capture.n_events == 1);
+    EXPECT(capture.events[0].kind == EV_ERROR);
+    EXPECT(strstr(capture.events[0].message, "stream ended before completion") != NULL);
+    EVENTS_FIXTURE_FREE(capture, parser);
+}
+
+static void test_native_finish_error_on_close_without_sentinel(void)
+{
+    EVENTS_FIXTURE(capture, parser);
+    feed_finish_native(&parser, "stop", "network_error");
+    EXPECT(capture.n_events == 0);
+    chat_events_finalize(&parser);
+    EXPECT(capture.n_events == 1);
+    EXPECT(capture.events[0].kind == EV_ERROR);
+    EXPECT(strstr(capture.events[0].message, "network_error") != NULL);
+    EVENTS_FIXTURE_FREE(capture, parser);
+}
+
+/* An upstream failure still leaves a usage footer, which owes the same attribution. */
+static void test_response_identity_survives_native_error(void)
+{
+    EVENTS_FIXTURE(capture, parser);
+    chat_events_feed(&parser, "{\"id\":\"gen-net\",\"model\":\"openai/gpt-4o-mini\","
+                              "\"provider\":\"OpenAI\",\"choices\":[{\"delta\":{},"
+                              "\"finish_reason\":\"stop\","
+                              "\"native_finish_reason\":\"network_error\"}]}");
+    chat_events_feed(&parser, "{\"choices\":[],\"usage\":{"
+                              "\"prompt_tokens\":1234,\"completion_tokens\":0}}");
+    chat_events_feed(&parser, "[DONE]");
+    EXPECT(capture.n_events == 1);
+    EXPECT(capture.events[0].kind == EV_ERROR);
+    EXPECT_STR_EQ(capture.events[0].response_id, "gen-net");
+    EXPECT_STR_EQ(capture.events[0].route, "OpenAI");
+    EXPECT(capture.events[0].usage.input_tokens == 1234);
+    EXPECT(capture.events[0].usage.output_tokens == 0);
+    EVENTS_FIXTURE_FREE(capture, parser);
+}
+
 static void test_done_sentinel(void)
 {
     EVENTS_FIXTURE(capture, parser);
@@ -838,6 +970,15 @@ int main(void)
     test_finish_reason_length_emits_error();
     test_finish_reason_length_error_on_close_without_sentinel();
     test_finish_reason_content_filter_emits_error();
+    test_native_finish_error_emits_error();
+    test_native_finish_benign_passthrough_keeps_done();
+    test_native_finish_error_without_reason_emits_error();
+    test_native_finish_benign_with_tool_calls_keeps_done();
+    test_finish_reason_error_emits_error();
+    test_native_error_dominates_truncation();
+    test_native_finish_benign_without_reason_is_not_a_finish();
+    test_native_finish_error_on_close_without_sentinel();
+    test_response_identity_survives_native_error();
     test_done_sentinel();
     test_double_termination_gated();
     test_events_after_terminal_ignored();


### PR DESCRIPTION
When a routed provider fails mid-request, OpenRouter returns HTTP 200 with empty content and a
benign `finish_reason`, signaling the failure only through `native_finish_reason`
(`network_error`, `error`) or the normalized finish reason `error`. hax rendered these streams
as empty successful responses.

The Chat Completions event parser now classifies these shapes as upstream errors and emits
`EV_ERROR` at stream termination, matching how truncation errors are already deferred and
reported:

- The `native_finish_reason` error sentinels and the normalized `finish_reason: "error"` produce
  an `upstream error: <detail>` event, preferring the native detail when present.
- An upstream error takes precedence over a simultaneous truncation reason.
- A benign `native_finish_reason` alone is not treated as a finish, so a stream dying after a
  native-only chunk still finalizes as `stream ended before completion` rather than an empty
  success. Other native passthrough values keep behaving as normal completions.

Covered by nine new unit tests in `tests/providers/test_chat_events.c`, including finalize
without `[DONE]`, response identity/usage attribution on the error event, and precedence over
truncation. Full test suite and `make lint` pass.
