### PR TITLE
Add Vertex AI provider

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -135,6 +135,8 @@ sources = files(
     'src/providers/stream_retry.c',
     'src/providers/usage_render.c',
     'src/providers/wire.c',
+    'src/providers/vertex.c',
+    'src/providers/vertex_auth.c',
 
     'src/render/ctrl_strip.c',
     'src/render/diff_color.c',

--- a/src/config.c
+++ b/src/config.c
@@ -227,6 +227,18 @@ static const struct config_setting REGISTRY[] = {
     {.key = "providers.anthropic-compatible.version", .env_var = "HAX_ANTHROPIC_VERSION",
      .description = "anthropic-version request header value (default: 2023-06-01)"},
 
+    /* vertex (Google's Anthropic Messages serving) */
+    {.key = "vertex.base_url", .env_var = "HAX_VERTEX_BASE_URL",
+     .description = "Complete Vertex `...:streamRawPredict` endpoint serving the Anthropic "
+                    "Messages protocol"},
+    {.key = "vertex.access_token", .env_var = "GOOGLE_OAUTH_ACCESS_TOKEN", .secret = 1,
+     .description = "Explicit Google OAuth2 access token for Vertex (instead of gcloud ADC)"},
+    {.key = "vertex.thinking_mode", .env_var = "HAX_VERTEX_THINKING_MODE",
+     .description = "Thinking mode: adaptive, budget, or off",
+     .choices = "adaptive|budget|off"},
+    {.key = "vertex.cache", .env_var = "HAX_VERTEX_CACHE", .choices = CONFIG_CHOICES_TRISTATE,
+     .description = "Send prompt cache_control breakpoints; auto uses the provider default"},
+
     /* per-provider */
     {.key = "providers.llamacpp.base_url", .env_var = "HAX_LLAMACPP_BASE_URL",
      .description = "Full llama-server base URL; overrides the port setting"},

--- a/src/providers/anthropic_body.c
+++ b/src/providers/anthropic_body.c
@@ -267,6 +267,10 @@ json_t *anthropic_build_body(const struct context *context, const char *provider
     if (opts->cache_markers)
         attach_cache_to_last_message(messages, opts->cache_ttl);
 
+    if (opts->anthropic_version) {
+        json_object_set_new(body, "anthropic_version", json_string(opts->anthropic_version));
+        json_object_del(body, "model");
+    }
     apply_thinking(body, context, opts);
     return body;
 }

--- a/src/providers/http_provider.c
+++ b/src/providers/http_provider.c
@@ -16,6 +16,7 @@
 #include "providers/chat_body.h"
 #include "providers/config_provider.h"
 #include "providers/stream_retry.h"
+#include "providers/vertex_auth.h"
 #include "providers/wire.h"
 #include "transport/api_error.h"
 #include "transport/http.h"
@@ -56,6 +57,8 @@ struct http_provider {
     enum anthropic_thinking_mode default_thinking_mode;
     int allow_empty_signature;
     int cache_default; /* Messages cache_control default; chat uses cache_mode */
+    int raw_endpoint;  /* base_url is the complete stream endpoint; no wire path is appended */
+    const char *(*bearer_token)(const struct provider *provider); /* Messages; NULL → api_key */
     char **extra_headers;
     json_t *extra_body;
 
@@ -114,7 +117,10 @@ static char **build_headers(const struct http_provider *provider, const struct w
     char *auth = NULL;
     char *version = NULL;
     if (wire == &WIRE_ANTHROPIC_MESSAGES) {
-        if (provider->api_key)
+        const char *token = provider->bearer_token ? provider->bearer_token(&provider->base) : NULL;
+        if (token && *token)
+            auth = xasprintf("Authorization: Bearer %s", token);
+        else if (provider->api_key)
             auth = xasprintf("x-api-key: %s", provider->api_key);
         version = xasprintf("anthropic-version: %s", provider->version);
     } else if (provider->api_key) {
@@ -144,6 +150,7 @@ struct http_stream {
     const struct wire *wire; /* resolved for this request's model */
     struct chat_cache_plan cache;
     union wire_events events;
+    int auth_retried; /* one in-place retry after a rejected bearer token */
 };
 
 static char **stream_build_headers(void *ctx)
@@ -180,6 +187,24 @@ static void stream_parser_free(void *ctx)
 {
     struct http_stream *stream = ctx;
     stream->wire->events_free(&stream->events);
+}
+
+/* A 401 on a Bearer-authenticated request (Vertex): the cached token may be rejected (expired
+ * access token, rotated refresh). Drop it and retry once so the next build_headers re-resolves.
+ * Bounded to a single recovery per stream; a second 401 surfaces as an error rather than
+ * spinning on a bad credential. */
+static int stream_recover(void *ctx, long http_status, http_tick_cb tick, void *tick_user)
+{
+    struct http_stream *stream = ctx;
+    if (http_status != 401 || stream->auth_retried)
+        return 0;
+    if (!stream->provider->bearer_token)
+        return 0;
+    stream->auth_retried = 1;
+    vertex_auth_invalidate();
+    (void)tick;
+    (void)tick_user;
+    return 1;
 }
 
 static int stream_parser_complete(void *ctx)
@@ -266,6 +291,8 @@ static int http_provider_stream(struct provider *base, const struct context *con
         opts.thinking_budget = config_scoped_int(provider->config_prefix, "thinking_budget");
         opts.show_reasoning = config_bool("show_reasoning");
         opts.allow_empty_signature = provider->allow_empty_signature;
+        if (provider->raw_endpoint)
+            opts.anthropic_version = provider->version;
     } else {
         /* Cache planning depends on rates populated by the startup metadata probe. Bounded: a
          * router-autoload probe can take minutes, while rate-reporting probes answer quickly,
@@ -294,6 +321,7 @@ static int http_provider_stream(struct provider *base, const struct context *con
         .body_len = strlen(body),
         .ctx = &stream,
         .build_headers = stream_build_headers,
+        .recover = provider->bearer_token ? stream_recover : NULL,
         .parser_init = stream_parser_init,
         .parser_feed = handle_sse_data,
         .parser_finalize = stream_parser_finalize,
@@ -596,12 +624,19 @@ struct provider *http_provider_new_preset(const struct http_provider_preset *pre
     provider->catalog_id = preset->catalog_id ? xstrdup(preset->catalog_id) : NULL;
     provider->config_prefix = preset->config_prefix ? xstrdup(preset->config_prefix) : NULL;
     provider->wire = resolve_wire(preset);
-    provider->endpoint = xasprintf("%s%s", provider->base_url, provider->wire->path);
+    provider->raw_endpoint = preset->raw_endpoint;
+    provider->bearer_token = preset->bearer_token;
+    /* A raw endpoint (Vertex) names the complete stream URL; wire paths derive per request. */
+    provider->endpoint = preset->raw_endpoint
+                             ? xstrdup(provider->base_url)
+                             : xasprintf("%s%s", provider->base_url, provider->wire->path);
     resolve_wire_rules(provider, preset->config_prefix);
     provider->catalog_wires = preset->catalog_wires;
     /* Resolved regardless of the default wire: per-model rules can route to Messages. */
     const char *version = config_scoped_str(preset->config_prefix, "version");
-    provider->version = xstrdup(version && *version ? version : MESSAGES_DEFAULT_VERSION);
+    const char *fallback = preset->default_version ? preset->default_version
+                                                   : MESSAGES_DEFAULT_VERSION;
+    provider->version = xstrdup(version && *version ? version : fallback);
 
     provider->send_cache_key = config_scoped_bool_or(preset->config_prefix, "send_cache_key",
                                                      preset->send_cache_key_default);

--- a/src/providers/http_provider.h
+++ b/src/providers/http_provider.h
@@ -42,6 +42,14 @@ struct http_provider_preset {
     enum anthropic_thinking_mode default_thinking_mode;
     int allow_empty_signature;      /* preserve unsigned thinking blocks on compat backends */
     int send_cache_control_default; /* overridable by the cache setting */
+    const char *default_version;    /* anthropic-version; NULL falls back to 2023-06-01 */
+
+    /* Vertex-style serving: base_url names a complete stream endpoint (a Google
+     * `...:streamRawPredict` URL) so no wire path is appended. */
+    int raw_endpoint;
+    /* Return the bearer token for a request; borrowed, may be NULL. Only consulted when the
+     * wire is Messages; NULL falls back to the configured API key behind a `Bearer ` header. */
+    const char *(*bearer_token)(const struct provider *provider);
 
     const char *const *extra_headers; /* NULL-terminated; copied */
 

--- a/src/providers/registry.c
+++ b/src/providers/registry.c
@@ -19,6 +19,7 @@ static const struct provider_factory *const BUILTINS[] = {
     &PROVIDER_OPENAI,
     &PROVIDER_ANTHROPIC,
     &PROVIDER_OPENROUTER,
+    &PROVIDER_VERTEX,
     &PROVIDER_MOCK,
 };
 // clang-format on

--- a/src/providers/registry.h
+++ b/src/providers/registry.h
@@ -15,6 +15,7 @@ extern const struct provider_factory PROVIDER_LLAMACPP;
 extern const struct provider_factory PROVIDER_MOCK;
 extern const struct provider_factory PROVIDER_OPENAI;
 extern const struct provider_factory PROVIDER_OPENROUTER;
+extern const struct provider_factory PROVIDER_VERTEX;
 
 /* Look up a built-in, recipe, or config-defined factory by name, accepting former ids. Built-in
  * names take precedence; returns NULL when no provider is registered. */

--- a/src/providers/vertex.c
+++ b/src/providers/vertex.c
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: MIT */
+#include "providers/vertex.h"
+
+#include <stdlib.h>
+
+#include "config.h"
+#include "provider.h"
+#include "util.h"
+#include "providers/anthropic_body.h"
+#include "providers/http_provider.h"
+#include "providers/vertex_auth.h"
+#include "providers/wire.h"
+
+/* Called by the shared Messages stream loop / metadata headers to authenticate every request. */
+static const char *vertex_bearer_token(const struct provider *base)
+{
+    (void)base;
+    char *error = NULL;
+    const char *token = vertex_auth_token(&error);
+    if (!token)
+        hax_warn("%s", error);
+    free(error);
+    return token;
+}
+
+struct provider *vertex_provider_new(const char *name)
+{
+    (void)name;
+    const char *base = config_str("vertex.base_url");
+    if (!base || !*base) {
+        hax_err("HAX_PROVIDER=vertex requires HAX_VERTEX_BASE_URL naming a Vertex "
+                "...:streamRawPredict endpoint");
+        return NULL;
+    }
+
+    struct http_provider_preset preset = {
+        .display_name = "vertex",
+        .config_prefix = "vertex",
+        .default_thinking_mode = ANTHROPIC_THINKING_BUDGET,
+        .allow_empty_signature = 1,
+        .send_cache_control_default = 0,
+        .default_version = "vertex-2023-10-16",
+        .raw_endpoint = 1,
+        .bearer_token = vertex_bearer_token,
+        .wire = &WIRE_ANTHROPIC_MESSAGES,
+    };
+    struct provider *provider = http_provider_new_preset(&preset);
+    if (!provider)
+        return NULL;
+    /* The endpoint URL is the per-model stream path; there is nothing to enumerate. */
+    provider->list_models = NULL;
+    provider->probe_model = NULL;
+    return provider;
+}
+
+static void vertex_prepare_availability(const char *name, struct provider_availability *out)
+{
+    (void)name;
+    const char *base = config_str("vertex.base_url");
+    const char *reason = NULL;
+    out->available = base && *base && vertex_auth_available(&reason);
+    if (!out->available)
+        out->reason = xstrdup(base && *base ? reason : "HAX_VERTEX_BASE_URL not set");
+}
+
+const struct provider_factory PROVIDER_VERTEX = {
+    .id = "vertex",
+    .new = vertex_provider_new,
+    .prepare_availability = vertex_prepare_availability,
+};

--- a/src/providers/vertex.h
+++ b/src/providers/vertex.h
@@ -1,0 +1,15 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_PROVIDERS_VERTEX_H
+#define HAX_PROVIDERS_VERTEX_H
+
+#include "provider.h"
+
+/* Construct the Google Vertex AI provider. It serves the Anthropic Messages protocol on a
+ * per-model "...:streamRawPredict" endpoint, authenticated with a Google OAuth2 Bearer token
+ * (see vertex_auth.h). vertex.base_url / HAX_VERTEX_BASE_URL must name the complete stream
+ * endpoint; model discovery is not possible, so set one with HAX_MODEL or /model. */
+struct provider *vertex_provider_new(const char *name);
+
+extern const struct provider_factory PROVIDER_VERTEX;
+
+#endif /* HAX_PROVIDERS_VERTEX_H */

--- a/src/providers/vertex_auth.c
+++ b/src/providers/vertex_auth.c
@@ -1,0 +1,246 @@
+/* SPDX-License-Identifier: MIT */
+#include "providers/vertex_auth.h"
+
+#include <jansson.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "config.h"
+#include "util.h"
+#include "system/path.h"
+#include "transport/http.h"
+
+#define VERTEX_OAUTH_URL "https://oauth2.googleapis.com/token"
+/* Test/instrumentation seam: overrides the token endpoint (a fixed public URL would make the
+ * full refresh flow untestable offline). */
+#define VERTEX_OAUTH_URL_ENV   "HAX_VERTEX_OAUTH_URL"
+#define VERTEX_TOKEN_MAX_BYTES (64 * 1024)
+#define VERTEX_TOKEN_TIMEOUT_S 10
+/* Refresh slightly early so an access token does not expire mid-request. */
+#define VERTEX_TOKEN_MARGIN_S 60
+/* gcloud's public OAuth client uses this well-known secret for user ADC. */
+#define VERTEX_GCLOUD_CLIENT_SECRET "gdf"
+
+static char *cached_token;
+static time_t cached_resolved_at;
+static long cached_expires_in;
+
+static const char *env_nonempty(const char *name)
+{
+    const char *value = getenv(name);
+    return value && *value ? value : NULL;
+}
+
+/* Percent-encode one byte for a form body. */
+static char *form_encode(const char *value)
+{
+    static const char hex[] = "0123456789ABCDEF";
+    struct buf out;
+    buf_init(&out);
+    for (const char *cursor = value; *cursor; cursor++) {
+        unsigned char byte = (unsigned char)*cursor;
+        if (('A' <= byte && byte <= 'Z') || ('a' <= byte && byte <= 'z') ||
+            ('0' <= byte && byte <= '9') || byte == '-' || byte == '_' || byte == '.' ||
+            byte == '~') {
+            buf_append(&out, cursor, 1);
+        } else {
+            char esc[3] = {'%', hex[byte >> 4], hex[byte & 0xF]};
+            buf_append(&out, esc, sizeof(esc));
+        }
+    }
+    return buf_steal(&out);
+}
+
+static char *default_adc_path(void)
+{
+    return path_expand_home("~/.config/gcloud/application_default_credentials.json");
+}
+
+/* Peek at the ADC file to classify its kind: "user" (refresh flow) or "service" (needs JWT).
+ * Returns NULL when no usable ADC file is present. */
+static json_t *load_adc_file(void)
+{
+    const char *configured = env_nonempty("GOOGLE_APPLICATION_CREDENTIALS");
+    char *path = configured ? xstrdup(configured) : default_adc_path();
+    if (!path)
+        return NULL;
+
+    size_t length = 0;
+    char *contents = slurp_file(path, &length);
+    free(path);
+    if (!contents)
+        return NULL;
+
+    json_t *root = json_loads(contents, 0, NULL);
+    free(contents);
+    if (!json_is_object(root)) {
+        json_decref(root);
+        return NULL;
+    }
+    return root;
+}
+
+int vertex_auth_available(const char **reason)
+{
+    if (reason)
+        *reason = NULL;
+
+    const char *literal = config_str("vertex.access_token");
+    if (!literal || !*literal)
+        literal = env_nonempty("GOOGLE_OAUTH_ACCESS_TOKEN");
+    if (literal)
+        return 1;
+
+    json_t *root = load_adc_file();
+    if (!root) {
+        if (reason)
+            *reason = "no Google ADC credentials (run `gcloud auth application-default login` "
+                      "or set GOOGLE_OAUTH_ACCESS_TOKEN)";
+        return 0;
+    }
+    int service_account = json_object_get(root, "private_key") != NULL;
+    int has_refresh = json_string_value(json_object_get(root, "refresh_token")) != NULL;
+    json_decref(root);
+    if (service_account) {
+        if (reason)
+            *reason = "service-account ADC is unsupported — run `gcloud auth "
+                      "application-default login` for a user credential";
+        return 0;
+    }
+    if (!has_refresh) {
+        if (reason)
+            *reason = "Google ADC file has no refresh_token";
+        return 0;
+    }
+    return 1;
+}
+
+/* Exchange the refresh token for a short-lived access token. */
+static int refresh_access_token(const char *client_id, const char *client_secret,
+                                const char *refresh_token)
+{
+    char *encoded_id = form_encode(client_id);
+    char *encoded_secret = form_encode(client_secret);
+    char *encoded_refresh = form_encode(refresh_token);
+    char *body = xasprintf("grant_type=refresh_token&client_id=%s&client_secret=%s"
+                           "&refresh_token=%s",
+                           encoded_id, encoded_secret, encoded_refresh);
+    free(encoded_id);
+    free(encoded_secret);
+    free(encoded_refresh);
+
+    const char *configured_url = env_nonempty(VERTEX_OAUTH_URL_ENV);
+    const char *url = configured_url ? configured_url : VERTEX_OAUTH_URL;
+    char *response = NULL;
+    long status = 0;
+    int result =
+        http_post(url, NULL, "application/x-www-form-urlencoded", body, strlen(body),
+                  VERTEX_TOKEN_TIMEOUT_S, VERTEX_TOKEN_MAX_BYTES, NULL, NULL, &response, &status);
+    free(body);
+    if (result != 0 || !response)
+        return -1;
+
+    json_error_t json_error;
+    json_t *root = json_loads(response, 0, &json_error);
+    free(response);
+    if (!json_is_object(root))
+        return -1;
+
+    const char *token = json_string_value(json_object_get(root, "access_token"));
+    if (!token || !*token) {
+        json_decref(root);
+        return -1;
+    }
+
+    free(cached_token);
+    cached_token = xstrdup(token);
+    cached_resolved_at = time(NULL);
+    cached_expires_in = 0;
+    json_t *expires = json_object_get(root, "expires_in");
+    if (json_is_integer(expires) && json_integer_value(expires) > 0)
+        cached_expires_in = (long)json_integer_value(expires);
+    json_decref(root);
+    return 0;
+}
+
+void vertex_auth_invalidate(void)
+{
+    free(cached_token);
+    cached_token = NULL;
+    cached_resolved_at = 0;
+    cached_expires_in = 0;
+}
+
+const char *vertex_auth_token(char **error)
+{
+    if (cached_token && cached_resolved_at > 0 && cached_expires_in > 0 &&
+        time(NULL) < cached_resolved_at + cached_expires_in - VERTEX_TOKEN_MARGIN_S)
+        return cached_token;
+
+    /* A literal token short-circuits file discovery (service-account workflows). It has no
+     * soft expiry; a rejected request calls vertex_auth_invalidate to re-read it. */
+    const char *literal = config_str("vertex.access_token");
+    if (!literal || !*literal)
+        literal = env_nonempty("GOOGLE_OAUTH_ACCESS_TOKEN");
+    if (literal) {
+        free(cached_token);
+        cached_token = xstrdup(literal);
+        cached_resolved_at = time(NULL);
+        cached_expires_in = 0;
+        return cached_token;
+    }
+
+    json_t *root = load_adc_file();
+    if (!root) {
+        if (error)
+            *error = xstrdup("no Google ADC credentials (run `gcloud auth application-default "
+                             "login` or set GOOGLE_OAUTH_ACCESS_TOKEN)");
+        return NULL;
+    }
+    if (json_object_get(root, "private_key")) {
+        if (error)
+            *error = xstrdup("service-account ADC is unsupported by hax (it needs a signed "
+                             "JWT); run `gcloud auth application-default login` or set "
+                             "GOOGLE_OAUTH_ACCESS_TOKEN to a manual access token");
+        json_decref(root);
+        return NULL;
+    }
+
+    const char *refresh_json = json_string_value(json_object_get(root, "refresh_token"));
+    const char *id_json = json_string_value(json_object_get(root, "client_id"));
+    const char *secret_json = json_string_value(json_object_get(root, "client_secret"));
+
+    char *refresh_token = refresh_json && *refresh_json ? xstrdup(refresh_json) : NULL;
+    char *client_id = id_json && *id_json ? xstrdup(id_json) : NULL;
+    char *client_secret = secret_json && *secret_json ? xstrdup(secret_json) : NULL;
+    json_decref(root);
+
+    if (!client_secret) {
+        const char *env_secret = env_nonempty("GOOGLE_OAUTH_CLIENT_SECRET");
+        if (env_secret)
+            client_secret = xstrdup(env_secret);
+        else
+            client_secret = xstrdup(VERTEX_GCLOUD_CLIENT_SECRET);
+    }
+
+    if (!refresh_token || !client_id) {
+        if (error)
+            *error = xstrdup("Google ADC file has no usable refresh_token/client_id");
+        free(refresh_token);
+        free(client_id);
+        free(client_secret);
+        return NULL;
+    }
+
+    int rc = refresh_access_token(client_id, client_secret, refresh_token);
+    free(refresh_token);
+    free(client_id);
+    free(client_secret);
+    if (rc != 0) {
+        if (error)
+            *error = xstrdup("OAuth token refresh failed");
+        return NULL;
+    }
+    return cached_token;
+}

--- a/src/providers/vertex_auth.h
+++ b/src/providers/vertex_auth.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_PROVIDERS_VERTEX_AUTH_H
+#define HAX_PROVIDERS_VERTEX_AUTH_H
+
+/* Google OAuth2 access token state for the Vertex provider. hax runs a single active provider,
+ * so the token lives in this module. */
+
+/* Return whether a credential source appears configured. Fills `reason` (may be NULL) with a
+ * static sentence when unavailable. */
+int vertex_auth_available(const char **reason);
+
+/* Return the process-wide bearer token, resolving from static key or gcloud user ADC and
+ * refreshing as needed. The token is borrowed and stays valid until the next call. Returns
+ * NULL with an allocated *error on failure. */
+const char *vertex_auth_token(char **error);
+
+/* Drop any cached token so the next vertex_auth_token re-resolves it (e.g. on a rejected
+ * request). */
+void vertex_auth_invalidate(void);
+
+#endif /* HAX_PROVIDERS_VERTEX_AUTH_H */

--- a/src/providers/wire.h
+++ b/src/providers/wire.h
@@ -44,6 +44,7 @@ struct wire_body_opts {
     int emit_progress; /* request llama.cpp prompt_progress */
     int request_cost;  /* request OpenRouter usage cost */
     /* anthropic */
+    const char *anthropic_version; /* non-NULL: emit as a body field (Vertex raw endpoints) */
     int max_tokens;
     enum anthropic_thinking_mode thinking_mode;
     int thinking_budget;       /* tokens; out-of-range values fall back to max_tokens - 1 */

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -65,6 +65,7 @@ test_sources = [
     'providers/test_responses_events.c',
     'providers/test_stream_retry.c',
     'providers/test_wire.c',
+    'providers/test_vertex.c',
 
     'render/test_ctrl_strip.c',
     'render/test_diff_color.c',

--- a/tests/providers/test_vertex.c
+++ b/tests/providers/test_vertex.c
@@ -1,0 +1,237 @@
+/* SPDX-License-Identifier: MIT */
+#include <errno.h>
+#include <poll.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include "config.h"
+#include "harness.h"
+#include "provider.h"
+#include "util.h"
+#include "providers/registry.h"
+#include "providers/vertex_auth.h"
+
+struct test_server {
+    int listener_fd;
+    int request_count; /* how many requests serve_requests accepts before returning */
+    const char *response;
+    char request_lines[8][512];
+    _Atomic int accepted;
+};
+
+static void *serve_requests(void *user)
+{
+    struct test_server *server = user;
+    for (int i = 0; i < server->request_count; i++) {
+        struct pollfd poll_fd = {.fd = server->listener_fd, .events = POLLIN};
+        if (poll(&poll_fd, 1, 10000) <= 0)
+            return NULL;
+
+        int client_fd = accept(server->listener_fd, NULL, NULL);
+        if (client_fd < 0)
+            return NULL;
+
+        char request[2048] = {0};
+        ssize_t bytes_read = read(client_fd, request, sizeof(request) - 1);
+        if (bytes_read > 0) {
+            char *line_end = strstr(request, "\r\n");
+            size_t line_length = line_end ? (size_t)(line_end - request) : strlen(request);
+            if (line_length >= sizeof(server->request_lines[i]))
+                line_length = sizeof(server->request_lines[i]) - 1;
+            memcpy(server->request_lines[i], request, line_length);
+            server->request_lines[i][line_length] = '\0';
+        }
+
+        dprintf(client_fd, "HTTP/1.1 200 OK\r\nContent-Length: %zu\r\nConnection: close\r\n\r\n%s",
+                strlen(server->response), server->response);
+        close(client_fd);
+    }
+    return NULL;
+}
+
+static int start_server(struct test_server *server, const char *response)
+{
+    server->response = response;
+    server->listener_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (server->listener_fd < 0)
+        return -1;
+
+    struct sockaddr_in address = {0};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (bind(server->listener_fd, (struct sockaddr *)&address, sizeof(address)) != 0 ||
+        listen(server->listener_fd, 2) != 0) {
+        close(server->listener_fd);
+        server->listener_fd = -1;
+        return -1;
+    }
+
+    socklen_t length = sizeof(address);
+    if (getsockname(server->listener_fd, (struct sockaddr *)&address, &length) != 0) {
+        close(server->listener_fd);
+        server->listener_fd = -1;
+        return -1;
+    }
+    return ntohs(address.sin_port);
+}
+
+static char *write_file(const char *name, const char *content)
+{
+    char *path = xasprintf("%s/%s", t_tempdir(), name);
+    FILE *file = fopen(path, "we");
+    if (!file) {
+        FAIL("fopen(%s): %s", path, strerror(errno));
+        free(path);
+        return NULL;
+    }
+    fputs(content, file);
+    fclose(file);
+    return path;
+}
+
+static void test_no_credentials(void)
+{
+    setenv("GOOGLE_APPLICATION_CREDENTIALS", "/dev/null/nonexistent", 1);
+    unsetenv("GOOGLE_OAUTH_ACCESS_TOKEN");
+    config_load("{}");
+
+    const char *reason = NULL;
+    EXPECT(!vertex_auth_available(&reason));
+    EXPECT(reason != NULL);
+
+    char *error = NULL;
+    EXPECT(vertex_auth_token(&error) == NULL);
+    EXPECT(error != NULL);
+    free(error);
+    config_free();
+}
+
+static void test_literal_token(void)
+{
+    unsetenv("GOOGLE_APPLICATION_CREDENTIALS");
+    unsetenv("GOOGLE_OAUTH_ACCESS_TOKEN");
+
+    config_load("{\"vertex\": {\"access_token\": \"ya29.literal\"}}");
+    EXPECT(vertex_auth_available(NULL));
+
+    char *error = NULL;
+    const char *token = vertex_auth_token(&error);
+    EXPECT(token != NULL);
+    if (token)
+        EXPECT_STR_EQ(token, "ya29.literal");
+    EXPECT(error == NULL);
+    free(error);
+
+    /* Invalidate forces re-resolution: the next call must observe the changed literal. */
+    config_load("{\"vertex\": {\"access_token\": \"ya29.rotated\"}}");
+    vertex_auth_invalidate();
+    token = vertex_auth_token(&error);
+    EXPECT(token != NULL);
+    if (token)
+        EXPECT_STR_EQ(token, "ya29.rotated");
+    EXPECT(error == NULL);
+    free(error);
+
+    vertex_auth_invalidate();
+    config_free();
+}
+
+static void test_service_account_rejected(void)
+{
+    char *path =
+        write_file("vertex-sa.json", "{\"private_key\": \"-----BEGIN PRIVATE KEY-----\", "
+                                     "\"client_email\": \"svc@example.iam.gserviceaccount.com\"}");
+    EXPECT(path != NULL);
+    unsetenv("GOOGLE_OAUTH_ACCESS_TOKEN");
+    setenv("GOOGLE_APPLICATION_CREDENTIALS", path ? path : "", 1);
+    config_load("{}");
+
+    const char *reason = NULL;
+    EXPECT(!vertex_auth_available(&reason));
+    EXPECT(reason != NULL);
+
+    char *error = NULL;
+    EXPECT(vertex_auth_token(&error) == NULL);
+    EXPECT(error != NULL);
+    free(error);
+
+    unsetenv("GOOGLE_APPLICATION_CREDENTIALS");
+    config_free();
+}
+
+/* User ADC (gcloud) credentials: a refresh token exchange against a loopback token endpoint. */
+static void test_user_refresh_flow(void)
+{
+    struct test_server server = {.request_count = 1};
+    int port = start_server(&server, "{\"access_token\":\"ya29.refreshed\",\"expires_in\":3600}");
+    if (port < 0) {
+        T_SKIP("cannot run a loopback server here");
+        return;
+    }
+
+    pthread_t thread;
+    if (pthread_create(&thread, NULL, serve_requests, &server) != 0) {
+        close(server.listener_fd);
+        T_SKIP("cannot start a loopback server thread");
+        return;
+    }
+
+    char *token_url = xasprintf("http://127.0.0.1:%d/token", port);
+    setenv("HAX_VERTEX_OAUTH_URL", token_url, 1);
+    free(token_url);
+    char *adc =
+        write_file("vertex-user.json", "{\"client_id\":\"client-1\",\"client_secret\":\"gdf\","
+                                       "\"refresh_token\":\"refresh-1\"}");
+    EXPECT(adc != NULL);
+    setenv("GOOGLE_APPLICATION_CREDENTIALS", adc ? adc : "", 1);
+    unsetenv("GOOGLE_OAUTH_ACCESS_TOKEN");
+    config_load("{}");
+
+    char *error = NULL;
+    const char *token = vertex_auth_token(&error);
+    EXPECT(token != NULL);
+    EXPECT(error == NULL);
+    if (token)
+        EXPECT_STR_EQ(token, "ya29.refreshed");
+    free(error);
+
+    pthread_join(thread, NULL);
+    close(server.listener_fd);
+    unsetenv("GOOGLE_APPLICATION_CREDENTIALS");
+    unsetenv("HAX_VERTEX_OAUTH_URL");
+    vertex_auth_invalidate();
+    config_free();
+}
+
+static void test_registry(void)
+{
+    EXPECT(provider_find("vertex") != NULL);
+    unsetenv("GOOGLE_APPLICATION_CREDENTIALS");
+    unsetenv("GOOGLE_OAUTH_ACCESS_TOKEN");
+    const struct provider_factory *factory = provider_find("vertex");
+
+    setenv("HAX_VERTEX_BASE_URL", "http://127.0.0.1:1/v1/...:streamRawPredict", 1);
+    config_load("{}");
+    struct provider *provider = factory ? factory->new(factory->id) : NULL;
+    EXPECT(provider != NULL);
+    if (provider)
+        provider->destroy(provider);
+    unsetenv("HAX_VERTEX_BASE_URL");
+    config_free();
+}
+
+int main(void)
+{
+    unsetenv("HAX_VERTEX_OAUTH_URL");
+    test_no_credentials();
+    test_literal_token();
+    test_service_account_rejected();
+    test_user_refresh_flow();
+    test_registry();
+    T_REPORT();
+}


### PR DESCRIPTION
Add a vertex provider for Google's Anthropic Messages serving, reachable at a complete ...:streamRawPredict URL. It authenticates with a Google OAuth2 bearer token resolved from GOOGLE_OAUTH_ACCESS_TOKEN or gcloud user ADC, with refresh-token exchange and cache invalidation on rejected requests.

- Extend struct http_provider_preset with raw_endpoint (base_url names the full stream endpoint, no wire path appended) and bearer_token (Messages providers may authenticate with Authorization: Bearer instead of x-api-key).
- Build the provider as an http_provider preset over the Messages wire; model enumeration and probing are disabled since the endpoint is per-model.
- Register PROVIDER_VERTEX in the built-in registry and declare vertex.* settings (base_url, access_token, thinking_mode, cache) in config.c.
- Add unit tests covering credential resolution: no credentials, literal token, service-account rejection, and the user ADC refresh flow against a loopback OAuth server.