### PR TITLE
Makefile: fix BSD make compatibility in symlink target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ install: all
 # with the dev binary linked there; the symlink tracks every rebuild.
 symlink: all
 	@mkdir -p "$(HOME)/.local/bin"
-	ln -sf "$(abspath $(BUILD_DIR))/hax" "$(HOME)/.local/bin/hax"
+	@build_dir_abs=$$(cd "$(BUILD_DIR)" && pwd); \
+	ln -sf "$$build_dir_abs/hax" "$(HOME)/.local/bin/hax"
 
 clean:
 	rm -rf $(BUILD_DIR)


### PR DESCRIPTION
Replace GNU make's $(abspath ...) with a portable shell command that works in both GNU make and BSD make.

The fix uses `cd $(BUILD_DIR) && pwd` at recipe execution time, which:
- Works in any make implementation (GNU, BSD, POSIX)
- Computes the path after the build directory exists (no silent failures)
- Avoids GNU-specific $(shell ...) or BSD-specific \::!= syntax