### PR TITLE
feat(config): add HAX_TEMPERATURE and HAX_TOP_P environment variable support

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -32,6 +32,10 @@ static const struct config_setting REGISTRY[] = {
      .description = "Model id (provider-specific; some auto-fill or require it)"},
     {.key = "effort", .env_var = "HAX_EFFORT", .keep_empty = 1,
      .description = "Reasoning effort (provider-specific); empty omits it"},
+    {.key = "temperature", .env_var = "HAX_TEMPERATURE", .keep_empty = 1,
+     .description = "Model temperature (provider-specific); empty omits it"},
+    {.key = "top_p", .env_var = "HAX_TOP_P", .keep_empty = 1,
+     .description = "Model top_p (provider-specific); empty omits it"},
     {.key = "system_prompt", .env_var = "HAX_SYSTEM_PROMPT", .keep_empty = 1,
      .description = "Replace the built-in base prompt (context sections still follow); @path "
                     "reads a file; (none) sends no system message at all"},

--- a/src/providers/anthropic_body.c
+++ b/src/providers/anthropic_body.c
@@ -284,6 +284,11 @@ json_t *anthropic_build_body(const struct context *context, const char *provider
     if (opts->cache_markers)
         attach_cache_to_last_message(messages, opts->cache_ttl);
 
+    if (opts->temperature)
+        json_object_set_new(body, "temperature", json_real(strtod(opts->temperature, NULL)));
+    if (opts->top_p)
+        json_object_set_new(body, "top_p", json_real(strtod(opts->top_p, NULL)));
+
     apply_thinking(body, context, opts);
     return body;
 }

--- a/src/providers/chat_body.c
+++ b/src/providers/chat_body.c
@@ -345,6 +345,11 @@ json_t *chat_build_body(const struct context *context, const char *provider_id, 
     if (opts->request_cost)
         json_object_set_new(body, "usage", json_pack("{s:b}", "include", 1));
 
+    if (opts->temperature)
+        json_object_set_new(body, "temperature", json_real(strtod(opts->temperature, NULL)));
+    if (opts->top_p)
+        json_object_set_new(body, "top_p", json_real(strtod(opts->top_p, NULL)));
+
     chat_apply_reasoning(body, opts->reasoning_format, context->effort);
     return body;
 }

--- a/src/providers/http_provider.c
+++ b/src/providers/http_provider.c
@@ -327,6 +327,8 @@ static int http_provider_stream(struct provider *base, const struct context *con
     struct http_stream stream = {.provider = provider, .wire = wire};
     struct wire_body_opts opts = {
         .extra_body = provider->extra_body,
+        .temperature = config_str("temperature"),
+        .top_p = config_str("top_p"),
         .cache_ttl = provider->cache_ttl,
     };
 

--- a/src/providers/responses_body.c
+++ b/src/providers/responses_body.c
@@ -149,5 +149,11 @@ json_t *responses_build_body(const struct context *context, const char *provider
     apply_reasoning(body, context->effort);
     if (opts && opts->session_cache_key)
         json_object_set_new(body, "prompt_cache_key", json_string(opts->session_cache_key));
+
+    if (opts && opts->temperature)
+        json_object_set_new(body, "temperature", json_real(strtod(opts->temperature, NULL)));
+    if (opts && opts->top_p)
+        json_object_set_new(body, "top_p", json_real(strtod(opts->top_p, NULL)));
+
     return body;
 }

--- a/src/providers/wire.h
+++ b/src/providers/wire.h
@@ -32,6 +32,8 @@ struct wire_events_opts {
 /* Per-request body options. Wires read only the fields their dialect defines. */
 struct wire_body_opts {
     const json_t *extra_body; /* user passthrough, merged over the finished body */
+    const char *temperature;
+    const char *top_p;
     /* chat + anthropic: send explicit cache markers with this ttl */
     int cache_markers;
     const char *cache_ttl;


### PR DESCRIPTION
### Summary
Adds support for configuring LLM sampling parameters via `HAX_TEMPERATURE` and `HAX_TOP_P` environment variables.

### Changes
- Parsed `HAX_TEMPERATURE` and `HAX_TOP_P` from environment in `src/config.c`.
- Integrated options with `wire_body_opts` in `src/providers/wire.h`.
- Updated provider request builders (`chat_body.c`, `anthropic_body.c`, `responses_body.c`) to forward the configured values when set.
- Validated with test suite.