### PR TITLE
Add OpenCode Go session header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ notes (see [docs/releasing.md](docs/releasing.md)).
 
 ### Fixed
 
+- OpenCode Go requests now include the required stable `x-opencode-session` header.
 - Interactively resuming an interrupted conversation (`--resume`, `-c`, `/resume`) now shows the
   resume hint and accepts the empty-Enter continue, which previously worked only within the
   interrupted process.

--- a/src/providers/http_provider.c
+++ b/src/providers/http_provider.c
@@ -52,6 +52,7 @@ struct http_provider {
     char *endpoint; /* for the default wire; other wires derive theirs per request */
     char *config_prefix;
     char *session_id;
+    const char *session_header;       /* borrowed from the def */
     const struct wire *wire;          /* default; wire_rules and catalog hints override per model */
     const struct wire *metadata_wire; /* auth scheme for /models and probe requests */
     struct wire_rule *wire_rules;
@@ -151,6 +152,7 @@ static char **build_headers(const struct http_provider *provider, const struct w
 
     char *auth = NULL;
     char *version = NULL;
+    char *session = NULL;
     if (wire == &WIRE_ANTHROPIC_MESSAGES) {
         if (provider->api_key)
             auth = xasprintf("x-api-key: %s", provider->api_key);
@@ -159,12 +161,17 @@ static char **build_headers(const struct http_provider *provider, const struct w
         auth = xasprintf("Authorization: Bearer %s", provider->api_key);
     }
 
-    const char *fixed[5];
+    if (provider->session_header)
+        session = xasprintf("%s: %s", provider->session_header, provider->session_id);
+
+    const char *fixed[6];
     size_t n_fixed = 0;
     if (auth)
         fixed[n_fixed++] = auth;
     if (version)
         fixed[n_fixed++] = version;
+    if (session)
+        fixed[n_fixed++] = session;
     if (streaming) {
         fixed[n_fixed++] = "Accept: text/event-stream";
         fixed[n_fixed++] = "Content-Type: application/json";
@@ -174,6 +181,7 @@ static char **build_headers(const struct http_provider *provider, const struct w
     char **headers = string_array_concat(fixed, (const char *const *)provider->extra_headers);
     free(auth);
     free(version);
+    free(session);
     return headers;
 }
 
@@ -899,6 +907,7 @@ struct provider *http_provider_new(const struct provider_def *def)
     char session_id[37];
     gen_uuid_v4(session_id);
     provider->session_id = xstrdup(session_id);
+    provider->session_header = def->session_header;
 
     if (def->load_defaults)
         def->load_defaults(&provider->default_model, &provider->default_effort);

--- a/src/providers/registry.c
+++ b/src/providers/registry.c
@@ -98,6 +98,7 @@ static const struct provider_def DEFS[] = {
         .api_key_env = "OPENCODE_API_KEY",
         .catalog_id = "opencode-go",
         .metadata_api = "openai",
+        .session_header = "x-opencode-session",
         .query_usage = opencode_go_query_usage,
     },
     /* Local servers. */

--- a/src/providers/registry.h
+++ b/src/providers/registry.h
@@ -75,6 +75,8 @@ struct provider_def {
                        char **error, http_tick_cb tick, void *tick_user);
     int (*query_usage)(struct provider *provider);
     char *(*model_label)(struct provider *provider, const char *model);
+    /* Request header carrying the provider's stable per-process session id; NULL sends none. */
+    const char *session_header;
     /* Owned NULL-terminated headers resolved once at construction and sent on every request. */
     char **(*static_headers)(void);
     /* Create the provider's dynamic credential source (http_provider.h), or return non-zero


### PR DESCRIPTION
Opencode Go now requires a special header.

See this email body I received:
<img width="1174" height="350" alt="image" src="https://github.com/user-attachments/assets/f40f2191-243d-4b52-9ea3-212b79183cf0" />

I tried to keep the change minimal, and conforming to the existing code style. Let me know if you'd like me to make changes. I hadn't interacted with C in many years, so I doubt I got this right, even with AI help.

Thanks!

## Summary

- send a stable `x-opencode-session` value with OpenCode Go requests
- declare the header name in the provider definition to keep the HTTP provider generic