### PR TITLE
Add configurable terminal themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ notes (see [docs/releasing.md](docs/releasing.md)).
 
 ### Added
 
+- Named custom terminal color and glyph themes in `config.json`, with inherited semantic color
+  roles, terminal palette/truecolor values, attributes, backgrounds, and model-output tints.
+  Separate glyph themes include prompt and message gutters, tool/picker marks, and spinner frames
+  with UTF-8 and ASCII defaults.
 - A resumed one-shot run no longer requires a prompt: `hax --resume=ID -p` (or `--json`)
   continues the conversation from where it stopped, including after an interrupt or pause.
 - `hax --json` (implies `-p`) streams the run as JSON lines on stdout for orchestrators and

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -238,8 +238,9 @@ provider-dependent.
 | `context_limit` | `HAX_CONTEXT_LIMIT` | auto | Override the model context-window size used for display and compaction. |
 | `display_width` | `HAX_DISPLAY_WIDTH` | `auto` | `auto`, `terminal`, or an exact width of at least 20 columns. |
 | `notify` | `HAX_NOTIFY` | `auto` | Completion notification: `auto`, `bel`, `osc9`, or `off`. |
-| `theme` | `HAX_THEME` | `auto` | `auto`, `dark`, `light`, `ansi`, or `off`. |
-| `tint` | `HAX_TINT` | `teal` | Model-output tint: `teal`, `violet`, `rose`, or `sage`. |
+| `theme` | `HAX_THEME` | `auto` | `auto`, a shipped theme, or a name in `themes`. |
+| `tint` | `HAX_TINT` | `teal` | Model-output tint: a shipped tint or the active custom theme's tint. |
+| `glyph_theme` | `HAX_GLYPH_THEME` | `auto` | UI glyph theme: `auto`, `utf8`, `ascii`, or a name in `glyph_themes`. |
 | `keep_awake` | `HAX_KEEP_AWAKE` | on | Best-effort idle-sleep inhibition while a turn runs. |
 | `compact.auto` | `HAX_COMPACT_AUTO` | on | Automatically summarize history near the context limit. |
 | `compact.threshold` | `HAX_COMPACT_THRESHOLD` | `85` | Context percentage that triggers automatic compaction. |
@@ -248,6 +249,56 @@ provider-dependent.
 `theme=auto` respects `NO_COLOR`, terminal color support, and `COLORFGBG` when available. Terminals
 rarely report a light background reliably, so set `light` explicitly if auto detection is wrong.
 `theme=ansi` uses the terminal's own 16-color palette; identity tints apply only to dark/light themes.
+
+### Themes and glyphs
+
+`themes` defines named color palettes. A custom theme inherits `dark`, `light`, or `ansi`; omitted
+roles inherit unchanged. A role is a color string or an object with `fg`, `bg`, `bold`, `dim`,
+`italic`, `underline`, and `reverse`. Colors may be a terminal color name, a 0–255 palette index,
+`#rrggbb`, or `default`. Theme entries never accept raw ANSI sequences.
+
+`glyph_theme=auto` selects the shipped `utf8` or `ascii` glyph theme from the locale. Custom
+`glyph_themes` use one string per mark and inherit the shipped UTF-8 theme for omitted marks.
+Spinner frame lists must be nonempty. Controls, zero-width characters, wide characters, ANSI
+sequences, and values over 16 UTF-8 bytes are rejected so input layout and animated redraws remain
+safe.
+
+```json
+{
+  "theme": "midnight",
+  "tint": "amber",
+  "glyph_theme": "minimal",
+  "themes": {
+    "midnight": {
+      "extends": "dark",
+      "roles": {
+        "accent": "#e5c07b",
+        "chrome": { "fg": "#61afef", "bold": true },
+        "heading": { "fg": "#c678dd", "bold": true },
+        "link": { "fg": "#61afef", "underline": true }
+      },
+      "tints": {
+        "amber": {
+          "stance": "#e5c07b",
+          "code_inline": "#e5c07b",
+          "code_block": "#d19a66"
+        }
+      }
+    }
+  },
+  "glyph_themes": {
+    "minimal": {
+      "prompt": "❯",
+      "user_gutter": "▌",
+      "banner_gutter": "▌",
+      "separator": "·",
+      "spinner": ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+      "tool_gutter": { "first": "┌", "body": "│", "last": "└", "marker": "›" },
+      "picker": { "search": "⌕", "selected": "→", "current": "✓" }
+    }
+  }
+}
+```
 
 ### Recording
 

--- a/meson.build
+++ b/meson.build
@@ -164,6 +164,7 @@ sources = files(
     'src/system/tempfiles.c',
 
     'src/terminal/clipboard.c',
+    'src/terminal/glyphs.c',
     'src/terminal/input.c',
     'src/terminal/input_core.c',
     'src/terminal/interrupt.c',

--- a/src/agent.c
+++ b/src/agent.c
@@ -34,10 +34,10 @@
 #include "render/spinner.h"
 #include "system/clock.h"
 #include "system/fs.h"
-#include "system/locale.h"
 #include "system/spawn.h"
 #include "system/tempfiles.h"
 #include "terminal/ansi.h"
+#include "terminal/glyphs.h"
 #include "terminal/input.h"
 #include "terminal/interrupt.h"
 #include "terminal/notify.h"
@@ -51,11 +51,8 @@
 /* Use ASCII unless wcwidth() can measure the themed UTF-8 glyph correctly. */
 static const char *build_prompt(char *buffer, size_t size)
 {
-    if (locale_have_utf8())
-        snprintf(buffer, size, "%s" ANSI_BOLD "❯" ANSI_BOLD_OFF "%s ", theme_open(THEME_ACCENT),
-                 theme_close(THEME_ACCENT));
-    else
-        snprintf(buffer, size, ANSI_BOLD ">" ANSI_BOLD_OFF " ");
+    snprintf(buffer, size, "%s" ANSI_BOLD "%s" ANSI_BOLD_OFF "%s ", theme_open(THEME_ACCENT),
+             glyph(GLYPH_PROMPT), theme_close(THEME_ACCENT));
     return buffer;
 }
 
@@ -110,6 +107,7 @@ static int reasoning_visible(void)
 void agent_display_refresh(struct agent_state *state)
 {
     theme_init();
+    glyphs_init();
     struct render_ctx *render = state->render;
     render->show_reasoning = reasoning_visible();
     if (render->md) {
@@ -1292,7 +1290,7 @@ int agent_run(struct provider **provider_io, const struct hax_opts *options)
     interrupt_init();
     interrupt_set_fatal_signal_hook(bash_shell_pgids_kill);
 
-    char prompt_buffer[64];
+    char prompt_buffer[128];
 
     for (;;) {
         disp_block_separator(&render.disp);

--- a/src/banner.c
+++ b/src/banner.c
@@ -10,6 +10,7 @@
 #include "provider.h"
 #include "xalloc.h"
 #include "terminal/ansi.h"
+#include "terminal/glyphs.h"
 #include "terminal/theme.h"
 #include "terminal/width.h"
 #include "text/width.h"
@@ -19,13 +20,14 @@
 
 static const char *banner_bar(char *buffer, size_t size)
 {
-    snprintf(buffer, size, "%s▌%s", theme_open(THEME_CHROME), theme_close(THEME_CHROME));
+    snprintf(buffer, size, "%s%s%s", theme_open(THEME_CHROME), glyph(GLYPH_BANNER_GUTTER),
+             theme_close(THEME_CHROME));
     return buffer;
 }
 
 void banner_open(struct banner_writer *w, FILE *out)
 {
-    char bar[32];
+    char bar[96];
     w->out = out;
     w->columns = display_width();
     w->col = BANNER_GUTTER_CELLS;
@@ -50,7 +52,7 @@ static void banner_style(struct banner_writer *w, const char *style_open, const 
 
 static void banner_row_break(struct banner_writer *w)
 {
-    char bar[32];
+    char bar[96];
     banner_style(w, NULL, NULL);
     fprintf(w->out, "\n%s   ", banner_bar(bar, sizeof(bar)));
     w->col = BANNER_INDENT_CELLS;
@@ -106,11 +108,14 @@ void banner_identity(FILE *out, const struct provider *provider,
         free(stance);
     }
     if (!provider) {
-        banner_put(&w, " ", ANSI_DIM, ANSI_BOLD_OFF, "› no provider — use /provider");
+        char *message = xasprintf("%s no provider — use /provider", glyph(GLYPH_TOOL_MARKER));
+        banner_put(&w, " ", ANSI_DIM, ANSI_BOLD_OFF, message);
+        free(message);
         banner_close(&w);
         return;
     }
-    char *head = xasprintf("› %s", provider->name ? provider->name : "?");
+    char *head =
+        xasprintf("%s %s", glyph(GLYPH_TOOL_MARKER), provider->name ? provider->name : "?");
     banner_put(&w, " ", ANSI_DIM, ANSI_BOLD_OFF, head);
     free(head);
     const char *model_label = session->model_label ? session->model_label : session->model;
@@ -118,10 +123,12 @@ void banner_identity(FILE *out, const struct provider *provider,
     if (!session->model || !*session->model)
         tail = xstrdup("no model — use /model (or /provider)");
     else if (session->effort)
-        tail = xasprintf("%s · %s", model_label, session->effort);
+        tail = xasprintf("%s %s %s", model_label, glyph(GLYPH_SEPARATOR), session->effort);
     else
         tail = xstrdup(model_label);
-    banner_put(&w, " · ", ANSI_DIM, ANSI_BOLD_OFF, tail);
+    char separator[GLYPH_MAX_BYTES + 3];
+    snprintf(separator, sizeof(separator), " %s ", glyph(GLYPH_SEPARATOR));
+    banner_put(&w, separator, ANSI_DIM, ANSI_BOLD_OFF, tail);
     free(tail);
     banner_close(&w);
 }
@@ -132,6 +139,8 @@ void banner_print(const struct provider *provider, const struct agent_session *s
     struct banner_writer w;
     banner_open(&w, stdout);
     banner_put(&w, "", ANSI_DIM, ANSI_BOLD_OFF, "ctrl-d quit");
-    banner_put(&w, " · ", ANSI_DIM, ANSI_BOLD_OFF, "try /help");
+    char separator[GLYPH_MAX_BYTES + 3];
+    snprintf(separator, sizeof(separator), " %s ", glyph(GLYPH_SEPARATOR));
+    banner_put(&w, separator, ANSI_DIM, ANSI_BOLD_OFF, "try /help");
     banner_close(&w);
 }

--- a/src/config.c
+++ b/src/config.c
@@ -18,6 +18,8 @@
 #include "xalloc.h"
 #include "system/fs.h"
 #include "system/path.h"
+#include "terminal/glyphs.h"
+#include "terminal/theme.h"
 #include "text/fmt.h"
 #include "text/utf8_sanitize.h"
 
@@ -75,12 +77,15 @@ static const struct config_setting REGISTRY[] = {
                     "(auto detects from the terminal)",
      .choices = "auto|bel|osc9|off", .editable = 1},
     {.key = "theme", .env_var = "HAX_THEME", .default_value = "auto",
-     .description = "Color theme: auto, dark, light, ansi, off (auto detects from the terminal)",
+     .description = "Color theme: auto, dark, light, ansi, off, or a name in themes",
      .choices = "auto|dark|light|ansi|off", .editable = 1},
     {.key = "tint", .env_var = "HAX_TINT", .default_value = "teal",
      .description = "Identity tint for model output; an active preset's own tint wins until set "
                     "here. Ignored by the ansi and off themes",
      .choices = "teal|violet|rose|sage", .editable = 1},
+    {.key = "glyph_theme", .env_var = "HAX_GLYPH_THEME", .default_value = "auto",
+     .description = "UI glyph theme: auto, utf8, ascii, or a name in glyph_themes",
+     .choices = "auto|utf8|ascii", .editable = 1},
 
     /* behavior */
     {.key = "keep_awake", .env_var = "HAX_KEEP_AWAKE", .default_value = "1",
@@ -912,6 +917,12 @@ int config_value_valid(const struct config_setting *setting, const char *value)
 {
     if (!setting || !value)
         return 0;
+    if (setting->key && strcmp(setting->key, "theme") == 0)
+        return theme_name_valid(value);
+    if (setting->key && strcmp(setting->key, "tint") == 0)
+        return theme_tint_valid(value);
+    if (setting->key && strcmp(setting->key, "glyph_theme") == 0)
+        return glyph_theme_name_valid(value);
     if (setting->choices && choice_value_valid(setting, value))
         return 1;
     if (setting->choices && setting->kind == CONFIG_KIND_STRING)

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 #include "transcript.h"
 #include "providers/registry.h"
 #include "system/locale.h"
+#include "terminal/glyphs.h"
 #include "terminal/theme.h"
 #include "transport/ca.h"
 
@@ -153,6 +154,7 @@ static void initialize_config(void)
     theme_set("auto");
     config_init();
     theme_init();
+    glyphs_init();
 }
 
 static void initialize_run_services(const char *resume_path)
@@ -207,6 +209,7 @@ int main(int argc, char **argv)
 
     /* A restored or newly applied preset may change the theme. */
     theme_init();
+    glyphs_init();
     initialize_run_services(resume_path);
 
     unsigned long diagnostics_before_provider = hax_diag_sequence();

--- a/src/render/spinner.c
+++ b/src/render/spinner.c
@@ -13,6 +13,7 @@
 #include "xalloc.h"
 #include "system/clock.h"
 #include "terminal/ansi.h"
+#include "terminal/glyphs.h"
 #include "terminal/theme.h"
 #include "terminal/width.h"
 #include "text/fmt.h"
@@ -26,12 +27,6 @@
 
 #define DEFAULT_LABEL     "working..."
 #define DEFAULT_LABEL_KEY "working"
-
-static const char *const SPINNER_FRAMES[] = {
-    "\xE2\xA0\x8B", "\xE2\xA0\x99", "\xE2\xA0\xB9", "\xE2\xA0\xB8", "\xE2\xA0\xBC",
-    "\xE2\xA0\xB4", "\xE2\xA0\xA6", "\xE2\xA0\xA7", "\xE2\xA0\x87", "\xE2\xA0\x8F",
-};
-#define SPINNER_FRAME_COUNT (sizeof(SPINNER_FRAMES) / sizeof(SPINNER_FRAMES[0]))
 
 enum spinner_mode {
     SPINNER_HIDDEN = 0,
@@ -77,8 +72,8 @@ const char *spinner_glyph_now(void)
     long now_ms = monotonic_ms();
     if (now_ms < 0)
         now_ms = 0;
-    size_t frame = (size_t)(now_ms / FRAME_INTERVAL_MS) % SPINNER_FRAME_COUNT;
-    return SPINNER_FRAMES[frame];
+    size_t frame = (size_t)(now_ms / FRAME_INTERVAL_MS);
+    return glyph_spinner_frame(frame);
 }
 
 /* Erasing the old row tail after repaint avoids a blank frame without synchronized output. */

--- a/src/render/tool_render.c
+++ b/src/render/tool_render.c
@@ -12,6 +12,7 @@
 #include "render/disp.h"
 #include "render/spinner.h"
 #include "terminal/ansi.h"
+#include "terminal/glyphs.h"
 #include "terminal/theme.h"
 #include "terminal/width.h"
 #include "text/utf8.h"
@@ -19,11 +20,6 @@
 #include "text/width.h"
 
 #define TAIL_RING_CAPACITY 1500
-
-static const char GUTTER_FIRST[] = "\xE2\x94\x8C";  /* ┌ */
-static const char GUTTER_BODY[] = "\xE2\x94\x82";   /* │ */
-static const char GUTTER_LAST[] = "\xE2\x94\x94";   /* └ */
-static const char GUTTER_MARKER[] = "\xE2\x80\xBA"; /* › */
 
 struct preview_limits {
     int head_lines;
@@ -120,7 +116,7 @@ static void write_gutter(struct disp *disp, const char *glyph)
 
 void tool_render_write_marker_gutter(struct disp *disp)
 {
-    write_gutter(disp, GUTTER_MARKER);
+    write_gutter(disp, glyph(GLYPH_TOOL_MARKER));
 }
 
 /* The one definition of a preview row's look; settled rows and live spinner rows share it. */
@@ -135,7 +131,8 @@ static void compose_row(struct buf *out, const char *gutter_glyph, const char *c
 
 static void write_next_row_gutter(struct tool_render *render)
 {
-    write_gutter(render->disp, render->rows_emitted == 0 ? GUTTER_FIRST : GUTTER_BODY);
+    write_gutter(render->disp,
+                 render->rows_emitted == 0 ? glyph(GLYPH_TOOL_FIRST) : glyph(GLYPH_TOOL_BODY));
 }
 
 /* The final newline remains pending, so a carriage return can replace the row's first cell. */
@@ -182,7 +179,7 @@ static void paint_live_rows(struct tool_render *render, const char *const *conte
     for (int row = 0; row < count; row++) {
         char *clipped = truncate_for_display(contents[row], budget);
         buf_init(&styled[row]);
-        compose_row(&styled[row], GUTTER_BODY, clipped);
+        compose_row(&styled[row], glyph(GLYPH_TOOL_BODY), clipped);
         rows[row].bytes = styled[row].data;
         rows[row].cells = TOOL_RENDER_GUTTER_COLS + (int)display_cells(clipped);
         free(clipped);
@@ -217,7 +214,8 @@ static void emit_row(struct tool_render *render, const char *content, size_t len
     char *truncated = truncate_slice(content, len);
     struct buf row;
     buf_init(&row);
-    compose_row(&row, render->rows_emitted == 0 ? GUTTER_FIRST : GUTTER_BODY, truncated);
+    compose_row(&row, render->rows_emitted == 0 ? glyph(GLYPH_TOOL_FIRST) : glyph(GLYPH_TOOL_BODY),
+                truncated);
     free(truncated);
     disp_commit_newlines(render->disp);
     disp_write(render->disp, row.data, row.len);
@@ -678,9 +676,9 @@ void tool_render_finalize(struct tool_render *render)
         finalize_capped_preview(render);
 
     if (render->rows_emitted >= 2)
-        overprint_final_gutter(render->disp, GUTTER_LAST);
+        overprint_final_gutter(render->disp, glyph(GLYPH_TOOL_LAST));
     else if (render->rows_emitted == 1)
-        overprint_final_gutter(render->disp, GUTTER_MARKER);
+        overprint_final_gutter(render->disp, glyph(GLYPH_TOOL_MARKER));
     spinner_swap_end(render->spinner);
     disp_flush(render->disp);
     render->block_open = 0;

--- a/src/terminal/glyphs.c
+++ b/src/terminal/glyphs.c
@@ -1,0 +1,326 @@
+/* SPDX-License-Identifier: MIT */
+#include "terminal/glyphs.h"
+
+#include <jansson.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include "config.h"
+#include "diag.h"
+#include "xalloc.h"
+#include "system/locale.h"
+#include "text/utf8.h"
+#include "text/width.h"
+
+static const char *const UTF8_GLYPHS[GLYPH_COUNT] = {
+    [GLYPH_PROMPT] = "❯",          [GLYPH_USER_GUTTER] = "▌",    [GLYPH_BANNER_GUTTER] = "▌",
+    [GLYPH_SEPARATOR] = "·",       [GLYPH_TOOL_FIRST] = "┌",     [GLYPH_TOOL_BODY] = "│",
+    [GLYPH_TOOL_LAST] = "└",       [GLYPH_TOOL_MARKER] = "›",    [GLYPH_PICKER_SEARCH] = "⌕",
+    [GLYPH_PICKER_SELECTED] = "→", [GLYPH_PICKER_CURRENT] = "✓",
+};
+
+static const char *const ASCII_GLYPHS[GLYPH_COUNT] = {
+    [GLYPH_PROMPT] = ">",          [GLYPH_USER_GUTTER] = "|",    [GLYPH_BANNER_GUTTER] = "|",
+    [GLYPH_SEPARATOR] = "|",       [GLYPH_TOOL_FIRST] = "+",     [GLYPH_TOOL_BODY] = "|",
+    [GLYPH_TOOL_LAST] = "+",       [GLYPH_TOOL_MARKER] = ">",    [GLYPH_PICKER_SEARCH] = "/",
+    [GLYPH_PICKER_SELECTED] = ">", [GLYPH_PICKER_CURRENT] = "*",
+};
+
+static const char *const UTF8_SPINNER[] = {"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"};
+static const char *const ASCII_SPINNER[] = {"-", "\\", "|", "/"};
+
+struct builtin_glyph_theme {
+    const char *name;
+    const char *const *glyphs;
+    const char *const *spinner;
+    size_t spinner_count;
+};
+
+static const struct builtin_glyph_theme BUILTIN_GLYPH_THEMES[] = {
+    {.name = "utf8",
+     .glyphs = UTF8_GLYPHS,
+     .spinner = UTF8_SPINNER,
+     .spinner_count = sizeof(UTF8_SPINNER) / sizeof(UTF8_SPINNER[0])},
+    {.name = "ascii",
+     .glyphs = ASCII_GLYPHS,
+     .spinner = ASCII_SPINNER,
+     .spinner_count = sizeof(ASCII_SPINNER) / sizeof(ASCII_SPINNER[0])},
+};
+
+struct glyph_entry {
+    enum glyph glyph;
+    const char *name;
+};
+
+static const struct glyph_entry GLYPH_ENTRIES[] = {
+    {GLYPH_PROMPT, "prompt"},
+    {GLYPH_USER_GUTTER, "user_gutter"},
+    {GLYPH_BANNER_GUTTER, "banner_gutter"},
+    {GLYPH_SEPARATOR, "separator"},
+};
+
+static const struct glyph_entry TOOL_GUTTER_ENTRIES[] = {
+    {GLYPH_TOOL_FIRST, "first"},
+    {GLYPH_TOOL_BODY, "body"},
+    {GLYPH_TOOL_LAST, "last"},
+    {GLYPH_TOOL_MARKER, "marker"},
+};
+
+static const struct glyph_entry PICKER_ENTRIES[] = {
+    {GLYPH_PICKER_SEARCH, "search"},
+    {GLYPH_PICKER_SELECTED, "selected"},
+    {GLYPH_PICKER_CURRENT, "current"},
+};
+
+static const char *active_glyphs[GLYPH_COUNT];
+static char *glyph_overrides[GLYPH_COUNT];
+static char **spinner_frames;
+static size_t spinner_count;
+
+static const struct builtin_glyph_theme *builtin_glyph_theme(const char *name)
+{
+    if (!name)
+        return NULL;
+    for (size_t i = 0; i < sizeof(BUILTIN_GLYPH_THEMES) / sizeof(BUILTIN_GLYPH_THEMES[0]); i++) {
+        if (strcasecmp(BUILTIN_GLYPH_THEMES[i].name, name) == 0)
+            return &BUILTIN_GLYPH_THEMES[i];
+    }
+    return NULL;
+}
+
+static int glyph_text_valid(const char *text)
+{
+    size_t length = text ? strlen(text) : 0;
+    if (!length || length > GLYPH_MAX_BYTES || !utf8_is_valid(text, length) ||
+        display_cells(text) != 1)
+        return 0;
+
+    for (size_t offset = 0; offset < length;) {
+        size_t bytes;
+        if (utf8_codepoint_cells(text, length, offset, &bytes) < 0)
+            return 0;
+        offset += bytes;
+    }
+    return 1;
+}
+
+static void free_spinner(void)
+{
+    for (size_t i = 0; i < spinner_count; i++)
+        free(spinner_frames[i]);
+    free(spinner_frames);
+    spinner_frames = NULL;
+    spinner_count = 0;
+}
+
+static void set_spinner(const char *const *frames, size_t count)
+{
+    free_spinner();
+    spinner_frames = xcalloc(count, sizeof(*spinner_frames));
+    spinner_count = count;
+    for (size_t i = 0; i < count; i++)
+        spinner_frames[i] = xstrdup(frames[i]);
+}
+
+static void select_builtin_theme(const struct builtin_glyph_theme *theme)
+{
+    for (int i = 0; i < GLYPH_COUNT; i++) {
+        free(glyph_overrides[i]);
+        glyph_overrides[i] = NULL;
+        active_glyphs[i] = theme->glyphs[i];
+    }
+    set_spinner(theme->spinner, theme->spinner_count);
+}
+
+static int load_glyph(enum glyph glyph, const char *name, json_t *node)
+{
+    const char *text = json_is_string(node) ? json_string_value(node) : NULL;
+    if (!text || !glyph_text_valid(text)) {
+        hax_warn("glyph theme %s must be one printable terminal cell", name);
+        return -1;
+    }
+    glyph_overrides[glyph] = xstrdup(text);
+    active_glyphs[glyph] = glyph_overrides[glyph];
+    return 0;
+}
+
+static void load_spinner(json_t *node)
+{
+    if (!json_is_array(node) || json_array_size(node) == 0) {
+        hax_warn("glyph theme spinner must be a nonempty array");
+        return;
+    }
+
+    size_t count = json_array_size(node);
+    char **frames = xcalloc(count, sizeof(*frames));
+    for (size_t i = 0; i < count; i++) {
+        const char *frame = json_is_string(json_array_get(node, i))
+                                ? json_string_value(json_array_get(node, i))
+                                : NULL;
+        if (!frame || !glyph_text_valid(frame)) {
+            hax_warn("glyph theme spinner[%zu] must be one printable terminal cell", i);
+            for (size_t j = 0; j < i; j++)
+                free(frames[j]);
+            free(frames);
+            return;
+        }
+        frames[i] = xstrdup(frame);
+    }
+
+    free_spinner();
+    spinner_frames = frames;
+    spinner_count = count;
+}
+
+static void load_entries(json_t *object, const struct glyph_entry *entries, size_t count)
+{
+    for (size_t i = 0; i < count; i++) {
+        json_t *node = json_object_get(object, entries[i].name);
+        if (node)
+            load_glyph(entries[i].glyph, entries[i].name, node);
+    }
+}
+
+static void load_glyphs(json_t *glyphs)
+{
+    load_entries(glyphs, GLYPH_ENTRIES, sizeof(GLYPH_ENTRIES) / sizeof(GLYPH_ENTRIES[0]));
+    json_t *tool_gutter = json_object_get(glyphs, "tool_gutter");
+    if (tool_gutter)
+        load_entries(tool_gutter, TOOL_GUTTER_ENTRIES,
+                     sizeof(TOOL_GUTTER_ENTRIES) / sizeof(TOOL_GUTTER_ENTRIES[0]));
+    json_t *picker = json_object_get(glyphs, "picker");
+    if (picker)
+        load_entries(picker, PICKER_ENTRIES, sizeof(PICKER_ENTRIES) / sizeof(PICKER_ENTRIES[0]));
+    json_t *spinner = json_object_get(glyphs, "spinner");
+    if (spinner)
+        load_spinner(spinner);
+}
+
+static int entries_valid(json_t *object, const struct glyph_entry *entries, size_t count)
+{
+    const char *name;
+    json_t *value;
+    json_object_foreach(object, name, value)
+    {
+        size_t i;
+        for (i = 0; i < count; i++)
+            if (strcmp(name, entries[i].name) == 0)
+                break;
+        if (i == count || !json_is_string(value) || !glyph_text_valid(json_string_value(value)))
+            return 0;
+    }
+    return 1;
+}
+
+static int spinner_valid(json_t *spinner)
+{
+    if (!spinner)
+        return 1;
+    if (!json_is_array(spinner) || json_array_size(spinner) == 0)
+        return 0;
+    for (size_t i = 0; i < json_array_size(spinner); i++) {
+        json_t *frame = json_array_get(spinner, i);
+        if (!json_is_string(frame) || !glyph_text_valid(json_string_value(frame)))
+            return 0;
+    }
+    return 1;
+}
+
+static int custom_glyph_theme_valid(json_t *glyphs)
+{
+    if (!json_is_object(glyphs))
+        return 0;
+    const char *name;
+    json_t *value;
+    json_object_foreach(glyphs, name, value)
+    {
+        if (strcmp(name, "spinner") == 0) {
+            if (!spinner_valid(value))
+                return 0;
+        } else if (strcmp(name, "tool_gutter") == 0) {
+            if (!json_is_object(value) ||
+                !entries_valid(value, TOOL_GUTTER_ENTRIES,
+                               sizeof(TOOL_GUTTER_ENTRIES) / sizeof(TOOL_GUTTER_ENTRIES[0])))
+                return 0;
+        } else if (strcmp(name, "picker") == 0) {
+            if (!json_is_object(value) ||
+                !entries_valid(value, PICKER_ENTRIES,
+                               sizeof(PICKER_ENTRIES) / sizeof(PICKER_ENTRIES[0])))
+                return 0;
+        } else if (!json_is_string(value) || !glyph_text_valid(json_string_value(value))) {
+            return 0;
+        } else {
+            size_t i;
+            for (i = 0; i < sizeof(GLYPH_ENTRIES) / sizeof(GLYPH_ENTRIES[0]); i++)
+                if (strcmp(name, GLYPH_ENTRIES[i].name) == 0)
+                    break;
+            if (i == sizeof(GLYPH_ENTRIES) / sizeof(GLYPH_ENTRIES[0]))
+                return 0;
+        }
+    }
+    return 1;
+}
+
+static json_t *custom_glyph_theme(const char *name)
+{
+    const json_t *themes = config_json_node("glyph_themes");
+    return json_is_object(themes) ? json_object_get(themes, name) : NULL;
+}
+
+int glyph_theme_name_valid(const char *name)
+{
+    return name && (strcasecmp(name, "auto") == 0 || builtin_glyph_theme(name) ||
+                    custom_glyph_theme_valid(custom_glyph_theme(name)));
+}
+
+static int glyph_theme_set(const char *name)
+{
+    if (!name)
+        return -1;
+    if (strcasecmp(name, "auto") == 0)
+        name = locale_have_utf8() ? "utf8" : "ascii";
+    const struct builtin_glyph_theme *builtin = builtin_glyph_theme(name);
+    if (builtin) {
+        select_builtin_theme(builtin);
+        return 0;
+    }
+    json_t *custom = custom_glyph_theme(name);
+    if (!custom_glyph_theme_valid(custom))
+        return -1;
+    select_builtin_theme(&BUILTIN_GLYPH_THEMES[0]);
+    load_glyphs(custom);
+    return 0;
+}
+
+void glyphs_init(void)
+{
+    const char *name = config_str("glyph_theme");
+    if (glyph_theme_set(name ? name : "auto") == 0)
+        return;
+    glyph_theme_set("auto");
+    hax_warn("unknown glyph theme '%s' (expected auto, utf8, ascii, or glyph_themes.<name>)",
+             name ? name : "");
+}
+
+const char *glyph(enum glyph glyph)
+{
+    if (glyph < 0 || glyph >= GLYPH_COUNT)
+        return "?";
+    return active_glyphs[glyph] ? active_glyphs[glyph] : UTF8_GLYPHS[glyph];
+}
+
+const char *glyph_spinner_frame(size_t frame)
+{
+    if (!spinner_count)
+        glyph_theme_set("auto");
+    return spinner_frames[frame % spinner_count];
+}
+
+size_t glyph_spinner_frame_count(void)
+{
+    if (!spinner_count)
+        glyph_theme_set("auto");
+    return spinner_count;
+}

--- a/src/terminal/glyphs.h
+++ b/src/terminal/glyphs.h
@@ -1,0 +1,38 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_TERMINAL_GLYPHS_H
+#define HAX_TERMINAL_GLYPHS_H
+
+#include <stddef.h>
+
+/* Configured glyphs are one terminal cell and no more than this many UTF-8 bytes. */
+#define GLYPH_MAX_BYTES 16
+
+enum glyph {
+    GLYPH_PROMPT,
+    GLYPH_USER_GUTTER,
+    GLYPH_BANNER_GUTTER,
+    GLYPH_SEPARATOR,
+    GLYPH_TOOL_FIRST,
+    GLYPH_TOOL_BODY,
+    GLYPH_TOOL_LAST,
+    GLYPH_TOOL_MARKER,
+    GLYPH_PICKER_SEARCH,
+    GLYPH_PICKER_SELECTED,
+    GLYPH_PICKER_CURRENT,
+    GLYPH_COUNT,
+};
+
+/* Return whether name selects auto, a shipped glyph theme, or a glyph_themes.<name> definition. */
+int glyph_theme_name_valid(const char *name);
+
+/* Load the selected glyph theme. Omitted marks inherit shipped UTF-8 glyphs. */
+void glyphs_init(void);
+
+/* Return a static, printable one-cell glyph selected for the active locale. */
+const char *glyph(enum glyph glyph);
+
+/* Return the configured animation frame and frame count. Frames are one terminal cell. */
+const char *glyph_spinner_frame(size_t frame);
+size_t glyph_spinner_frame_count(void);
+
+#endif /* HAX_TERMINAL_GLYPHS_H */

--- a/src/terminal/input.c
+++ b/src/terminal/input.c
@@ -25,6 +25,7 @@
 #include "system/path.h"
 #include "system/spawn.h"
 #include "terminal/ansi.h"
+#include "terminal/glyphs.h"
 #include "terminal/input_core.h"
 #include "terminal/theme.h"
 #include "terminal/ui.h"
@@ -557,7 +558,8 @@ static void submitted_emit(const struct input_render_event *event, void *user)
         buf_append_str(frame, theme_close(THEME_ACCENT));
         buf_append_str(frame, ANSI_ERASE_LINE "\r\n");
         buf_append_str(frame, theme_open(THEME_ACCENT));
-        buf_append_str(frame, "▌ ");
+        buf_append_str(frame, glyph(GLYPH_USER_GUTTER));
+        buf_append_str(frame, " ");
     }
 }
 
@@ -567,7 +569,8 @@ static void append_user_message(struct buf *frame, const char *text, size_t len,
     const int body_column = 2;
 
     buf_append_str(frame, theme_open(THEME_ACCENT));
-    buf_append_str(frame, "▌ ");
+    buf_append_str(frame, glyph(GLYPH_USER_GUTTER));
+    buf_append_str(frame, " ");
     input_core_render(text, len, 0, body_column, body_column, display_columns, submitted_emit,
                       frame, NULL);
     buf_append_str(frame, theme_close(THEME_ACCENT));

--- a/src/terminal/picker.c
+++ b/src/terminal/picker.c
@@ -14,6 +14,7 @@
 #include "xalloc.h"
 #include "system/locale.h"
 #include "terminal/ansi.h"
+#include "terminal/glyphs.h"
 #include "terminal/input_core.h"
 #include "terminal/picker_core.h"
 #include "terminal/theme.h"
@@ -247,13 +248,14 @@ static int append_clipped_line(struct buf *output, const char *line, size_t line
 static void render_search(struct buf *output, const struct picker *picker, int terminal_cols,
                           int use_utf8)
 {
-    const char *icon = use_utf8 ? "\xe2\x8c\x95 " : "/ "; /* ⌕ */
+    const char *icon = glyph(GLYPH_PICKER_SEARCH);
     int text_cells = terminal_cols - PICKER_MARKER_CELLS;
     if (text_cells < 0)
         text_cells = 0;
 
     buf_append_str(output, ANSI_DIM);
     buf_append_str(output, icon);
+    buf_append_str(output, " ");
 
     if (picker->core.query.len == 0) {
         char placeholder[48];
@@ -294,13 +296,21 @@ static void render_row(struct buf *output, const struct picker *picker, size_t m
 
     if (selected)
         buf_append_str(output, theme_open(THEME_ACCENT));
-    buf_append_str(output, selected ? (use_utf8 ? "\xe2\x86\x92 " : "> ") : "  "); /* → */
+    if (selected) {
+        buf_append_str(output, glyph(GLYPH_PICKER_SELECTED));
+        buf_append_str(output, " ");
+    } else {
+        buf_append_str(output, "  ");
+    }
     if (selected)
         buf_append_str(output, theme_close(THEME_ACCENT));
 
-    const char *current_tag =
-        item->current ? (use_utf8 ? "\xe2\x9c\x93 current" : "* current") : NULL; /* ✓ */
-    int current_tag_cells = current_tag ? PICKER_CURRENT_TAG_CELLS : 0;
+    char current_tag_text[GLYPH_MAX_BYTES + sizeof(" current")];
+    const char *current = glyph(GLYPH_PICKER_CURRENT);
+    if (item->current)
+        snprintf(current_tag_text, sizeof(current_tag_text), "%s current", current);
+    const char *current_tag = item->current ? current_tag_text : NULL;
+    int current_tag_cells = current_tag ? (int)display_cells(current_tag) : 0;
 
     const char *separator = item->dim ? (use_utf8 ? " \xe2\x80\x93 " : " - ") : "  "; /* – */
     int separator_cells =

--- a/src/terminal/picker_core.c
+++ b/src/terminal/picker_core.c
@@ -4,8 +4,10 @@
 #include <string.h>
 
 #include "buf.h"
+#include "terminal/glyphs.h"
 #include "terminal/picker.h"
 #include "text/utf8.h"
+#include "text/width.h"
 
 int picker_core_text_cells(const char *text)
 {
@@ -28,7 +30,7 @@ int picker_core_label_cells(const struct picker_item *item, int terminal_cols)
     if (row_cells < 1)
         row_cells = 1;
 
-    int current_cells = item->current ? PICKER_CURRENT_TAG_CELLS : 0;
+    int current_cells = item->current ? (int)display_cells(glyph(GLYPH_PICKER_CURRENT)) + 8 : 0;
     int separator_cells =
         item->dim ? PICKER_DIM_DETAIL_SEPARATOR_CELLS : PICKER_DETAIL_SEPARATOR_CELLS;
     int available_cells = row_cells - current_cells;

--- a/src/terminal/picker_core.h
+++ b/src/terminal/picker_core.h
@@ -8,7 +8,7 @@
 #include "terminal/picker.h"
 
 #define PICKER_MARKER_CELLS               2
-#define PICKER_CURRENT_TAG_CELLS          11
+#define PICKER_CURRENT_TAG_CELLS          9
 #define PICKER_DETAIL_SEPARATOR_CELLS     2
 #define PICKER_DIM_DETAIL_SEPARATOR_CELLS 3
 

--- a/src/terminal/theme.c
+++ b/src/terminal/theme.c
@@ -1,6 +1,9 @@
 /* SPDX-License-Identifier: MIT */
 #include "terminal/theme.h"
 
+#include <errno.h>
+#include <jansson.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
@@ -175,6 +178,23 @@ static const struct tint TINTS[] = {
 static const struct theme_preset *active_theme = &THEME_PRESETS[0];
 static const struct tint *active_tint = &TINTS[0];
 
+struct custom_theme {
+    struct theme_preset preset;
+    char *name;
+    char *opens[THEME_ROLE_COUNT];
+    char *closes[THEME_ROLE_COUNT];
+};
+
+static struct custom_theme custom_theme;
+
+struct custom_tint {
+    char *name;
+    char *opens[THEME_ROLE_COUNT];
+    char *closes[THEME_ROLE_COUNT];
+};
+
+static struct custom_tint custom_tint;
+
 static const struct tint *tint_find(const char *name)
 {
     if (!name)
@@ -209,11 +229,15 @@ static const char *resolve_role_open(const char *const *tint_opens, enum theme_r
 
 const char *theme_open(enum theme_role role)
 {
+    if (active_theme->tint_palette != TINT_PALETTE_NONE && custom_tint.opens[role])
+        return custom_tint.opens[role];
     return resolve_role_open(tint_role_opens(active_tint), role);
 }
 
 const char *theme_close(enum theme_role role)
 {
+    if (active_theme->tint_palette != TINT_PALETTE_NONE && custom_tint.opens[role])
+        return custom_tint.closes[role];
     const char *close = active_theme->roles[role].close;
     return close ? close : "";
 }
@@ -225,11 +249,14 @@ const char *theme_name(void)
 
 const char *theme_tint_name(void)
 {
-    return active_tint->name;
+    return custom_tint.name ? custom_tint.name : active_tint->name;
 }
 
 const char *theme_tint_open(const char *name)
 {
+    if (active_theme->tint_palette != TINT_PALETTE_NONE && name && custom_tint.name &&
+        strcasecmp(name, custom_tint.name) == 0)
+        return custom_tint.opens[THEME_STANCE];
     const struct tint *tint = tint_find(name);
     if (!tint)
         return NULL;
@@ -260,26 +287,368 @@ static const char *autodetect_theme(void)
     return "dark";
 }
 
+static void custom_theme_free(struct custom_theme *theme)
+{
+    free(theme->name);
+    for (int role = 0; role < THEME_ROLE_COUNT; role++) {
+        free(theme->opens[role]);
+        free(theme->closes[role]);
+    }
+    memset(theme, 0, sizeof(*theme));
+}
+
+static const struct theme_preset *builtin_theme(const char *name)
+{
+    for (size_t i = 0; i < sizeof(THEME_PRESETS) / sizeof(THEME_PRESETS[0]); i++)
+        if (strcasecmp(THEME_PRESETS[i].name, name) == 0)
+            return &THEME_PRESETS[i];
+    return NULL;
+}
+
+static int color_code(json_t *value, int background, char *buffer, size_t size)
+{
+    const char *text = json_is_string(value) ? json_string_value(value) : NULL;
+    long indexed = json_is_integer(value) ? json_integer_value(value) : -2;
+    if (text && strcasecmp(text, "default") == 0) {
+        snprintf(buffer, size, "%d", background ? 49 : 39);
+        return 0;
+    }
+    if (text && text[0] == '#' && strlen(text) == 7) {
+        for (size_t i = 1; i < 7; i++)
+            if (!((text[i] >= '0' && text[i] <= '9') || (text[i] >= 'a' && text[i] <= 'f') ||
+                  (text[i] >= 'A' && text[i] <= 'F')))
+                return -1;
+        char pair[3] = {0};
+        pair[0] = text[1];
+        pair[1] = text[2];
+        int red = (int)strtol(pair, NULL, 16);
+        pair[0] = text[3];
+        pair[1] = text[4];
+        int green = (int)strtol(pair, NULL, 16);
+        pair[0] = text[5];
+        pair[1] = text[6];
+        int blue = (int)strtol(pair, NULL, 16);
+        snprintf(buffer, size, "%d;2;%d;%d;%d", background ? 48 : 38, red, green, blue);
+        return 0;
+    }
+    if (text) {
+        static const struct {
+            const char *name;
+            int code;
+        } NAMES[] = {{"black", 0},         {"red", 1},
+                     {"green", 2},         {"yellow", 3},
+                     {"blue", 4},          {"magenta", 5},
+                     {"cyan", 6},          {"white", 7},
+                     {"bright-black", 8},  {"bright-red", 9},
+                     {"bright-green", 10}, {"bright-yellow", 11},
+                     {"bright-blue", 12},  {"bright-magenta", 13},
+                     {"bright-cyan", 14},  {"bright-white", 15}};
+        for (size_t i = 0; i < sizeof(NAMES) / sizeof(NAMES[0]); i++) {
+            if (strcasecmp(text, NAMES[i].name) != 0)
+                continue;
+            int code = NAMES[i].code;
+            snprintf(buffer, size, "%d", (background ? 40 : 30) + code + (code >= 8 ? 52 : 0));
+            return 0;
+        }
+        char *end;
+        errno = 0;
+        indexed = strtol(text, &end, 10);
+        if (errno || *end)
+            return -1;
+    }
+    if (indexed < 0 || indexed > 255)
+        return -1;
+    snprintf(buffer, size, "%d;5;%ld", background ? 48 : 38, indexed);
+    return 0;
+}
+
+static int role_number(const char *name)
+{
+    static const char *const NAMES[] = {
+        "accent", "chrome", "chrome_dim", "stance", "code_inline", "code_block", "heading",
+        "link",   "add",    "remove",     "ok",     "error",       "warn"};
+    for (size_t i = 0; i < sizeof(NAMES) / sizeof(NAMES[0]); i++)
+        if (strcmp(name, NAMES[i]) == 0)
+            return (int)i;
+    return -1;
+}
+
+static int append_sgr_code(char *codes, size_t size, const char *code)
+{
+    size_t length = strlen(codes);
+    return snprintf(codes + length, size - length, "%s%s", length ? ";" : "", code) >=
+                   (int)(size - length)
+               ? -1
+               : 0;
+}
+
+static int style_key_valid(const char *name)
+{
+    return strcmp(name, "fg") == 0 || strcmp(name, "bg") == 0 || strcmp(name, "bold") == 0 ||
+           strcmp(name, "dim") == 0 || strcmp(name, "italic") == 0 ||
+           strcmp(name, "underline") == 0 || strcmp(name, "reverse") == 0;
+}
+
+static int custom_role_style(json_t *value, char **open, char **close)
+{
+    json_t *fg = value;
+    json_t *bg = NULL;
+    int bold = 0;
+    int dim = 0;
+    int italic = 0;
+    int underline = 0;
+    int reverse = 0;
+    if (json_is_object(value)) {
+        const char *key;
+        json_t *member;
+        json_object_foreach(value, key, member)
+        {
+            if (!style_key_valid(key))
+                return -1;
+        }
+        fg = json_object_get(value, "fg");
+        bg = json_object_get(value, "bg");
+#define STYLE_BOOL(key, target)                                                                    \
+    do {                                                                                           \
+        member = json_object_get(value, key);                                                      \
+        if (member && !json_is_boolean(member))                                                    \
+            return -1;                                                                             \
+        (target) = json_is_true(member);                                                           \
+    } while (0)
+        STYLE_BOOL("bold", bold);
+        STYLE_BOOL("dim", dim);
+        STYLE_BOOL("italic", italic);
+        STYLE_BOOL("underline", underline);
+        STYLE_BOOL("reverse", reverse);
+#undef STYLE_BOOL
+        if (fg && !json_is_string(fg) && !json_is_integer(fg))
+            return -1;
+        if (bg && !json_is_string(bg) && !json_is_integer(bg))
+            return -1;
+    } else if (!json_is_string(value) && !json_is_integer(value)) {
+        return -1;
+    }
+
+    char codes[64] = "";
+    char color[24];
+    if (bold && append_sgr_code(codes, sizeof(codes), "1"))
+        return -1;
+    if (dim && append_sgr_code(codes, sizeof(codes), "2"))
+        return -1;
+    if (italic && append_sgr_code(codes, sizeof(codes), "3"))
+        return -1;
+    if (underline && append_sgr_code(codes, sizeof(codes), "4"))
+        return -1;
+    if (reverse && append_sgr_code(codes, sizeof(codes), "7"))
+        return -1;
+    if (fg) {
+        if (color_code(fg, 0, color, sizeof(color)) || append_sgr_code(codes, sizeof(codes), color))
+            return -1;
+    }
+    if (bg) {
+        if (color_code(bg, 1, color, sizeof(color)) || append_sgr_code(codes, sizeof(codes), color))
+            return -1;
+    }
+    if (!codes[0])
+        return -1;
+
+    *open = xasprintf(ANSI_CSI "%sm", codes);
+    char closes[24] = "";
+    if (bold || dim)
+        append_sgr_code(closes, sizeof(closes), "22");
+    if (italic)
+        append_sgr_code(closes, sizeof(closes), "23");
+    if (underline)
+        append_sgr_code(closes, sizeof(closes), "24");
+    if (reverse)
+        append_sgr_code(closes, sizeof(closes), "27");
+    if (fg)
+        append_sgr_code(closes, sizeof(closes), "39");
+    if (bg)
+        append_sgr_code(closes, sizeof(closes), "49");
+    *close = closes[0] ? xasprintf(ANSI_CSI "%sm", closes) : xstrdup("");
+    return 0;
+}
+
+static int custom_tint_roles_valid(json_t *roles)
+{
+    if (!json_is_object(roles))
+        return -1;
+    const char *role_name;
+    json_t *value;
+    json_object_foreach(roles, role_name, value)
+    {
+        int role = role_number(role_name);
+        char *open = NULL;
+        char *close = NULL;
+        if (role < THEME_STANCE || role > THEME_LINK || custom_role_style(value, &open, &close)) {
+            free(open);
+            free(close);
+            return -1;
+        }
+        free(open);
+        free(close);
+    }
+    return 0;
+}
+
+static int custom_tints_valid(json_t *tints)
+{
+    if (!tints)
+        return 0;
+    if (!json_is_object(tints))
+        return -1;
+    const char *name;
+    json_t *roles;
+    json_object_foreach(tints, name, roles)
+    {
+        if (custom_tint_roles_valid(roles))
+            return -1;
+    }
+    return 0;
+}
+
+static int custom_theme_load(const char *name, struct custom_theme *loaded)
+{
+    const json_t *themes = config_json_node("themes");
+    json_t *definition = json_is_object(themes) ? json_object_get(themes, name) : NULL;
+    if (!json_is_object(definition))
+        return -1;
+
+    json_t *extends_value = json_object_get(definition, "extends");
+    if (extends_value && !json_is_string(extends_value))
+        return -1;
+    const char *extends = extends_value ? json_string_value(extends_value) : "dark";
+    const struct theme_preset *base = builtin_theme(extends);
+    if (!base || strcmp(base->name, "off") == 0)
+        return -1;
+    json_t *roles = json_object_get(definition, "roles");
+    if (roles && !json_is_object(roles))
+        return -1;
+    if (custom_tints_valid(json_object_get(definition, "tints")))
+        return -1;
+
+    loaded->preset = *base;
+    loaded->preset.name = loaded->name = xstrdup(name);
+    if (!roles)
+        return 0;
+    const char *role_name;
+    json_t *value;
+    json_object_foreach(roles, role_name, value)
+    {
+        int role = role_number(role_name);
+        if (role < 0 || custom_role_style(value, &loaded->opens[role], &loaded->closes[role]))
+            return -1;
+        loaded->preset.roles[role].open = loaded->opens[role];
+        loaded->preset.roles[role].close = loaded->closes[role];
+    }
+    return 0;
+}
+
+int theme_name_valid(const char *name)
+{
+    if (!name)
+        return 0;
+    if (strcasecmp(name, "auto") == 0 || builtin_theme(name))
+        return 1;
+    struct custom_theme loaded = {0};
+    int valid = custom_theme_load(name, &loaded) == 0;
+    custom_theme_free(&loaded);
+    return valid;
+}
+
+static void custom_tint_free(void)
+{
+    free(custom_tint.name);
+    for (int role = 0; role < THEME_ROLE_COUNT; role++) {
+        free(custom_tint.opens[role]);
+        free(custom_tint.closes[role]);
+    }
+    memset(&custom_tint, 0, sizeof(custom_tint));
+}
+
+static json_t *custom_tint_roles(const char *name)
+{
+    if (!custom_theme.name)
+        return NULL;
+    const json_t *themes = config_json_node("themes");
+    json_t *definition = json_is_object(themes) ? json_object_get(themes, custom_theme.name) : NULL;
+    json_t *tints = json_is_object(definition) ? json_object_get(definition, "tints") : NULL;
+    return json_is_object(tints) ? json_object_get(tints, name) : NULL;
+}
+
+static int custom_tint_load(const char *name)
+{
+    json_t *roles = custom_tint_roles(name);
+    if (!json_is_object(roles))
+        return -1;
+
+    struct custom_tint loaded = {.name = xstrdup(name)};
+    const char *role_name;
+    json_t *value;
+    json_object_foreach(roles, role_name, value)
+    {
+        int role = role_number(role_name);
+        if (role < THEME_STANCE || role > THEME_LINK ||
+            custom_role_style(value, &loaded.opens[role], &loaded.closes[role])) {
+            free(loaded.name);
+            for (int i = 0; i < THEME_ROLE_COUNT; i++) {
+                free(loaded.opens[i]);
+                free(loaded.closes[i]);
+            }
+            return -1;
+        }
+    }
+    custom_tint_free();
+    custom_tint = loaded;
+    return 0;
+}
+
+int theme_tint_valid(const char *name)
+{
+    if (!name)
+        return 0;
+    if (tint_find(name))
+        return 1;
+    return custom_tint_roles_valid(custom_tint_roles(name)) == 0;
+}
+
 int theme_set(const char *name)
 {
     if (!name)
         return -1;
     if (strcasecmp(name, "auto") == 0)
         name = autodetect_theme();
-    for (size_t i = 0; i < sizeof(THEME_PRESETS) / sizeof(THEME_PRESETS[0]); i++) {
-        if (strcasecmp(THEME_PRESETS[i].name, name) == 0) {
-            active_theme = &THEME_PRESETS[i];
-            return 0;
-        }
+    const struct theme_preset *builtin = builtin_theme(name);
+    if (builtin) {
+        custom_tint_free();
+        custom_theme_free(&custom_theme);
+        active_theme = builtin;
+        return 0;
     }
-    return -1;
+
+    struct custom_theme loaded = {0};
+    if (custom_theme_load(name, &loaded) != 0) {
+        custom_theme_free(&loaded);
+        return -1;
+    }
+    custom_tint_free();
+    custom_theme_free(&custom_theme);
+    custom_theme = loaded;
+    active_theme = &custom_theme.preset;
+    return 0;
 }
 
 int theme_tint_set(const char *name)
 {
+    if (!name)
+        return -1;
+    if (custom_tint_load(name) == 0)
+        return 0;
     const struct tint *tint = tint_find(name);
     if (!tint)
         return -1;
+    custom_tint_free();
     active_tint = tint;
     return 0;
 }
@@ -319,13 +688,16 @@ void theme_init(void)
     if (theme_set(theme) != 0) {
         theme_set("auto");
         if (invalid_value_changed(&last_invalid_theme, theme))
-            hax_warn("unknown theme '%s' (expected auto, dark, light, ansi, or off)", theme);
+            hax_warn("unknown theme '%s' (expected auto, dark, light, ansi, off, or themes.<name>)",
+                     theme);
     }
 
     const char *tint = configured_tint();
     if (theme_tint_set(tint) != 0) {
         theme_tint_set("teal");
         if (invalid_value_changed(&last_invalid_tint, tint))
-            hax_warn("unknown tint '%s' (expected teal, violet, rose, or sage)", tint);
+            hax_warn(
+                "unknown tint '%s' (expected teal, violet, rose, sage, or an active theme tint)",
+                tint);
     }
 }

--- a/src/terminal/theme.h
+++ b/src/terminal/theme.h
@@ -27,10 +27,16 @@ enum theme_role {
 const char *theme_open(enum theme_role role);
 const char *theme_close(enum theme_role role);
 
-/* Select auto, dark, light, ansi, or off by case-insensitive name. "auto" inspects NO_COLOR, TERM,
- * COLORTERM, and COLORFGBG. The initial theme is "ansi". Return 0 on success or -1 without
- * changing the current theme. */
+/* Return whether name selects a shipped theme or a theme declared in config.json. */
+int theme_name_valid(const char *name);
+
+/* Select auto, dark, light, ansi, off, or a declared custom theme by name. "auto" inspects
+ * NO_COLOR, TERM, COLORTERM, and COLORFGBG. The initial theme is "ansi". Return 0 on success or
+ * -1 without changing the current theme. */
 int theme_set(const char *name);
+
+/* Return whether name selects a shipped tint or a tint declared by the active custom theme. */
+int theme_tint_valid(const char *name);
 
 /* Select teal, violet, rose, or sage by case-insensitive name. Tints affect only the stance and
  * Markdown roles, and do not apply to the ansi or off themes. The initial tint is "teal". Return 0

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -94,6 +94,7 @@ test_sources = [
     'system/test_tempfiles.c',
 
     'terminal/test_clipboard.c',
+    'terminal/test_glyphs.c',
     'terminal/test_input.c',
     'terminal/test_input_core.c',
     'terminal/test_interrupt.c',

--- a/tests/terminal/test_glyphs.c
+++ b/tests/terminal/test_glyphs.c
@@ -1,0 +1,83 @@
+/* SPDX-License-Identifier: MIT */
+#include <string.h>
+
+#include "config.h"
+#include "harness.h"
+#include "system/locale.h"
+#include "terminal/glyphs.h"
+
+static void test_defaults(void)
+{
+    glyphs_init();
+    EXPECT_STR_EQ(glyph(GLYPH_PROMPT), "❯");
+    EXPECT(glyph_spinner_frame_count() == 10);
+    EXPECT_STR_EQ(glyph_spinner_frame(0), "⠋");
+}
+
+static void test_builtin_ascii_theme(void)
+{
+    EXPECT(config_load("{\"glyph_theme\": \"ascii\"}") == 0);
+    glyphs_init();
+    EXPECT_STR_EQ(glyph(GLYPH_PROMPT), ">");
+    EXPECT_STR_EQ(glyph(GLYPH_PICKER_CURRENT), "*");
+    EXPECT(glyph_spinner_frame_count() == 4);
+    EXPECT_STR_EQ(glyph_spinner_frame(1), "\\");
+    EXPECT(config_load(NULL) == 0);
+    glyphs_init();
+}
+
+static void test_custom_glyph_theme(void)
+{
+    EXPECT(config_load("{\"glyph_theme\": \"custom\", \"glyph_themes\": {\"custom\": {"
+                       "\"prompt\": \"$\", \"user_gutter\": \"!\","
+                       " \"spinner\": [\".\", \"o\"]}, \"other\": {\"prompt\": \"?\"}}}") == 0);
+    const struct config_setting *glyph_theme = config_setting_find("glyph_theme");
+    EXPECT(config_value_valid(glyph_theme, "custom"));
+    EXPECT(!config_value_valid(glyph_theme, "missing"));
+    glyphs_init();
+    EXPECT_STR_EQ(glyph(GLYPH_PROMPT), "$");
+    EXPECT_STR_EQ(glyph(GLYPH_USER_GUTTER), "!");
+    EXPECT(glyph_spinner_frame_count() == 2);
+    EXPECT_STR_EQ(glyph_spinner_frame(0), ".");
+    EXPECT_STR_EQ(glyph_spinner_frame(1), "o");
+    EXPECT_STR_EQ(glyph_spinner_frame(2), ".");
+    config_set_override("glyph_theme", "other");
+    glyphs_init();
+    EXPECT_STR_EQ(glyph(GLYPH_PROMPT), "?");
+    config_set_override("glyph_theme", NULL);
+    EXPECT(config_load(NULL) == 0);
+    glyphs_init();
+}
+
+static void test_invalid_glyph_theme(void)
+{
+    EXPECT(config_load("{\"glyph_theme\": \"custom\", \"glyph_themes\": {\"custom\": {"
+                       "\"tool_gutter\": \"+\", \"picker\": {\"unknown\": \"*\"}}}}") == 0);
+    const struct config_setting *glyph_theme = config_setting_find("glyph_theme");
+    EXPECT(!config_value_valid(glyph_theme, "custom"));
+    glyphs_init();
+    EXPECT_STR_EQ(glyph(GLYPH_PROMPT), "❯");
+    EXPECT(config_load(NULL) == 0);
+    glyphs_init();
+}
+
+static void test_glyph_byte_limit(void)
+{
+    EXPECT(config_load("{\"glyph_theme\": \"custom\", \"glyph_themes\": {\"custom\": {\"prompt\":"
+                       " \".\\u0301\\u0301\\u0301\\u0301\\u0301\\u0301\\u0301\\u0301\"}}}") == 0);
+    glyphs_init();
+    EXPECT_STR_EQ(glyph(GLYPH_PROMPT), "❯");
+    EXPECT(config_load(NULL) == 0);
+    glyphs_init();
+}
+
+int main(void)
+{
+    locale_init_utf8();
+    test_defaults();
+    test_builtin_ascii_theme();
+    test_custom_glyph_theme();
+    test_invalid_glyph_theme();
+    test_glyph_byte_limit();
+    T_REPORT();
+}

--- a/tests/terminal/test_theme.c
+++ b/tests/terminal/test_theme.c
@@ -276,6 +276,53 @@ static void test_background_autodetection(void)
     unsetenv("COLORFGBG");
 }
 
+static void test_custom_theme(void)
+{
+    EXPECT(config_load("{\"themes\": {\"midnight\": {\"extends\": \"dark\", \"roles\": {"
+                       "\"accent\": \"#e5c07b\", \"chrome\": {\"fg\": 33, \"bold\": true},"
+                       " \"link\": {\"fg\": \"bright-cyan\", \"underline\": true}},"
+                       " \"tints\": {\"amber\": {\"stance\": \"#e5c07b\","
+                       " \"code_inline\": \"#e5c07b\"}}}}}") == 0);
+    const struct config_setting *theme = config_setting_find("theme");
+    EXPECT(config_value_valid(theme, "midnight"));
+    EXPECT(!config_value_valid(theme, "dawn"));
+    config_set_override("theme", "midnight");
+    theme_init();
+    const struct config_setting *tint = config_setting_find("tint");
+    EXPECT(config_value_valid(tint, "amber"));
+    EXPECT(!config_value_valid(tint, "ochre"));
+    EXPECT_STR_EQ(theme_name(), "midnight");
+    EXPECT_STR_EQ(theme_open(THEME_ACCENT), "\x1b[38;2;229;192;123m");
+    EXPECT_STR_EQ(theme_close(THEME_ACCENT), ANSI_FG_DEFAULT);
+    EXPECT_STR_EQ(theme_open(THEME_CHROME), "\x1b[1;38;5;33m");
+    EXPECT_STR_EQ(theme_close(THEME_CHROME), "\x1b[22;39m");
+    EXPECT_STR_EQ(theme_open(THEME_LINK), "\x1b[4;96m");
+    EXPECT_STR_EQ(theme_close(THEME_LINK), "\x1b[24;39m");
+    config_set_override("tint", "amber");
+    theme_init();
+    EXPECT_STR_EQ(theme_tint_name(), "amber");
+    EXPECT_STR_EQ(theme_open(THEME_STANCE), "\x1b[38;2;229;192;123m");
+    EXPECT(theme_set("dark") == 0);
+    config_set_override("theme", NULL);
+    config_set_override("tint", NULL);
+    EXPECT(config_load(NULL) == 0);
+}
+
+static void test_invalid_custom_theme(void)
+{
+    EXPECT(config_load("{\"themes\": {\"bad-extends\": {\"extends\": 1},"
+                       " \"bad-roles\": {\"roles\": []},"
+                       " \"bad-style\": {\"roles\": {\"accent\": {\"fg\": \"red\","
+                       " \"blink\": true}}},"
+                       " \"bad-tint\": {\"tints\": {\"amber\": []}}}}") == 0);
+    EXPECT(!theme_name_valid("bad-extends"));
+    EXPECT(!theme_name_valid("bad-roles"));
+    EXPECT(!theme_name_valid("bad-style"));
+    EXPECT(!theme_name_valid("bad-tint"));
+    EXPECT(theme_set("bad-style") == -1);
+    EXPECT(config_load(NULL) == 0);
+}
+
 static void test_config_resolution(void)
 {
     setenv("TERM", "xterm-256color", 1);
@@ -406,6 +453,8 @@ int main(void)
     test_no_color_autodetection();
     test_terminal_capability_autodetection();
     test_background_autodetection();
+    test_custom_theme();
+    test_invalid_custom_theme();
     test_config_resolution();
     test_preset_tint_precedence();
     test_masked_invalid_tint_warning();

--- a/tests/test_agent.c
+++ b/tests/test_agent.c
@@ -16,6 +16,7 @@
 #include "session.h"
 #include "xalloc.h"
 #include "render/render_ctx.h"
+#include "system/locale.h"
 
 /* Run `body` with captured stdout, restore stdout, and return owned output. */
 static char *capture_stdout(void (*body)(void *), void *user)
@@ -894,6 +895,7 @@ static void test_undo_intact_when_truncate_fails(void)
 
 int main(void)
 {
+    locale_init_utf8();
     test_apply_settings_empty_reprints_banner();
     test_apply_settings_nonempty_prints_marker();
     test_apply_settings_quiet_prints_nothing();

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -12,6 +12,7 @@
 #include "harness.h"
 #include "xalloc.h"
 #include "system/fs.h"
+#include "terminal/theme.h"
 
 /* Isolate resolution tests from the developer or CI environment. */
 static void clear_env(void)
@@ -881,6 +882,31 @@ static void test_choice_value_validation(void)
     EXPECT(!config_value_valid(theme, "dar"));
     EXPECT(!config_value_valid(theme, "darker"));
     EXPECT(!config_value_valid(theme, ""));
+}
+
+static void test_custom_theme_value_validation(void)
+{
+    clear_env();
+    EXPECT(config_load("{\"themes\": {\"midnight\": {\"tints\": {\"amber\": {"
+                       "\"stance\": \"yellow\"}}}}, \"presets\": {\"review\": {"
+                       "\"provider\": \"mock\", \"tint\": \"amber\"}}}") == 0);
+
+    const struct config_setting *theme = config_setting_find("theme");
+    const struct config_setting *tint = config_setting_find("tint");
+    EXPECT(config_value_valid(theme, "midnight"));
+    EXPECT(theme_set("midnight") == 0);
+    EXPECT(config_value_valid(tint, "amber"));
+
+    char *err = NULL;
+    EXPECT(config_preset_apply("review", CONFIG_TIER_RUN, &err) == 0);
+    EXPECT(err == NULL);
+    config_preset_exit(CONFIG_TIER_RUN);
+    config_set_override("preset", NULL);
+    config_set_override("provider", NULL);
+    config_set_override("model", NULL);
+    config_set_override("effort", NULL);
+    EXPECT(config_load(NULL) == 0);
+    EXPECT(theme_set("ansi") == 0);
 }
 
 static void test_sort_models_auto(void)
@@ -2195,6 +2221,7 @@ int main(void)
     test_string_and_integer_value_validation();
     test_bounded_and_scaled_value_validation();
     test_choice_value_validation();
+    test_custom_theme_value_validation();
     test_sort_models_auto();
     test_empty_policy();
     test_nested_and_flat();


### PR DESCRIPTION
## Summary
- Add named custom color themes with inherited semantic roles, model-output tints, and terminal
  palette/truecolor styles.
- Add independent `utf8`, `ascii`, and custom glyph themes for prompts, gutters, pickers, tools,
  and spinners.
- Refresh colors and glyphs after live `/config` changes.
- Document the configuration format and add validation coverage.

## Considerations
- Color and glyph selection are independent: `theme` controls styles, while `glyph_theme` controls
  marks.
- `glyph_theme=auto` selects shipped UTF-8 or ASCII glyphs from locale support.
- Custom glyph themes inherit shipped UTF-8 glyphs for omitted marks.
- Glyph values are limited to one printable terminal cell and 16 UTF-8 bytes, preventing layout and
  redraw issues.
- Custom themes are validated before selection; invalid runtime values fall back to automatic
  defaults.

## Testing
- `make tests` — 119 passed.
- `make lint` — blocked by existing repository-wide clang-tidy diagnostics, including signed-bitwise
  findings outside this change.
