### PR TITLE
Add Vertex AI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,13 @@ notes (see [docs/releasing.md](docs/releasing.md)).
 
 ### Added
 
+- `vertex` provider for Claude on Vertex AI: hosts the Anthropic Messages endpoint
+  (`.../locations/{loc}/publishers/anthropic/models/{model}:streamRawPredict`), authenticates with
+  a Google access token (explicit `providers.vertex.access_token`, an ADC `authorized_user` file's
+  refresh flow, or `gcloud auth application-default print-access-token`), and list its models
+  from the catalog (`google-vertex-anthropic`). Configure it with `providers.vertex.project` and
+  optionally `providers.vertex.location` (default `us-east5`; `global`, `us`, and `eu` select the
+  multi-region hosts).
 - `hax --json` (implies `-p`) streams new conversation records as JSONL, followed by a `result`
   record with the outcome, final text, cost, and session id. Plain `-p` output is unchanged, and
   the session-file schema is now a supported read surface. See [docs/sessions.md](docs/sessions.md).
@@ -91,6 +98,11 @@ notes (see [docs/releasing.md](docs/releasing.md)).
 - OpenCode Go usage-window limits now surface immediately instead of triggering futile retries.
 - The retry indicator shows the active attempt after backoff instead of remaining at
   "retrying in 1s" while the request is in flight.
+- The `vertex` path template now resolves `{location}`/`{project}` from the same single source as
+  the base-URL host: the config registry honors `CLOUD_ML_REGION` and `ANTHROPIC_VERTEX_PROJECT_ID`
+  as fallback environment variables and applies the `us-east5` default, instead of silently
+  dropping `{location}` and producing a malformed `.../locations//...` endpoint when only
+  `CLOUD_ML_REGION` was set.
 
 ## [0.4.0] - 2026-08-22
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -175,6 +175,40 @@ Requests carry the conversation id as `x-opencode-session`, which the gateway re
 routing and prompt caching, and `x-opencode-client: hax`. Both can be overridden in
 `extra_headers` ([below](#request-passthrough)).
 
+## Vertex AI
+
+Vertex AI serves Claude through the Anthropic Messages protocol under a URL that carries the
+project, location, and model:
+
+```sh
+export HAX_PROVIDER=vertex
+export GOOGLE_CLOUD_PROJECT=my-gcp-project     # or ANTHROPIC_VERTEX_PROJECT_ID
+```
+
+hax builds the endpoint's host from the location: `global` uses `aiplatform.googleapis.com`,
+`us`/`eu` use the multi-region replica hosts, and any other value uses `{location}-aiplatform.
+googleapis.com`. Point an explicit `providers.vertex.base_url` at anything else to override the
+host rule verbatim.
+
+Credentials are a Google access token, resolved in this order:
+
+1. `providers.vertex.access_token` or `GOOGLE_OAUTH_ACCESS_TOKEN` — used as-is (no refresh).
+2. An Application Default Credentials `authorized_user` file (from
+   `gcloud auth application-default login`), refreshed in place through its own client id.
+3. Any other ADC shape (service account, workload identity federation, impersonation) — resolved
+   through `gcloud auth application-default print-access-token`.
+
+There is no `/login`; Google owns that flow (`gcloud auth application-default login`).
+
+`/model` is populated from hax's model catalog (`google-vertex-anthropic`) rather than a network
+listing, because the raw-predict endpoint serves no `/models` route. Claude-only for now: Gemini on
+Vertex speaks a different protocol, and the OpenAI-compatible route degrades multi-turn tool use, so
+it is a config recipe rather than a built-in.
+
+Vertex caps a request at about 30 MB; a long image-heavy session can hit that before the 1M-token
+window. When a request is rejected for its payload size, hax points at trimming context or images
+(`/compact`). The catalog's Vertex rates do not model the regional/multi-region premium.
+
 ## llama.cpp
 
 `llama.cpp` selects the convenience provider for a local `llama-server` at

--- a/meson.build
+++ b/meson.build
@@ -135,6 +135,7 @@ sources = files(
     'src/providers/responses_events.c',
     'src/providers/stream_retry.c',
     'src/providers/usage_render.c',
+    'src/providers/vertex.c',
     'src/providers/wire.c',
 
     'src/render/ctrl_strip.c',

--- a/src/catalog.c
+++ b/src/catalog.c
@@ -537,6 +537,55 @@ static void fill_from_cache(const char *provider_id, const char *model, struct c
     json_decref(provider);
 }
 
+/* Append the keys of a models-bearing JSON object, deduplicated against what we already hold. */
+static void add_model_ids(char ***ids, size_t *count, size_t *capacity, json_t *object)
+{
+    if (!json_is_object(object))
+        return;
+    const char *model;
+    json_t *value;
+    json_object_foreach(object, model, value)
+    {
+        if (!model || !*model)
+            continue;
+        int seen = 0;
+        for (size_t i = 0; i < *count; i++)
+            if (strcmp((*ids)[i], model) == 0) {
+                seen = 1;
+                break;
+            }
+        if (seen)
+            continue;
+        if (*count == *capacity) {
+            *capacity = *capacity ? *capacity * 2 : 8;
+            *ids = xrealloc(*ids, *capacity * sizeof(**ids));
+        }
+        (*ids)[(*count)++] = xstrdup(model);
+    }
+}
+
+/* Snapshot and config tiers together with config taking precedence. */
+char **catalog_list_model_ids(const char *provider_id, const char *catalog_id, size_t *count)
+{
+    *count = 0;
+    char **ids = NULL;
+    size_t capacity = 0;
+
+    const json_t *config_models = config_json_node("catalog.models");
+    if (json_is_object(config_models)) {
+        add_model_ids(&ids, count, &capacity, json_object_get(config_models, provider_id));
+        if (catalog_id && provider_id && strcmp(catalog_id, provider_id) != 0)
+            add_model_ids(&ids, count, &capacity, json_object_get(config_models, catalog_id));
+    }
+    if (catalog_id && *catalog_id) {
+        json_t *slice = cache_provider_slice(catalog_id);
+        if (json_is_object(slice))
+            add_model_ids(&ids, count, &capacity, json_object_get(slice, "models"));
+        json_decref(slice);
+    }
+    return ids; /* NULL when nothing was collected */
+}
+
 /* ---------------- cache-tier memo (foreground thread) ---------------- */
 
 /* Only the foreground accesses the memo; the worker publishes refreshes via the generation. */

--- a/src/catalog.h
+++ b/src/catalog.h
@@ -99,6 +99,11 @@ void catalog_lookup_many(const char *provider_id, const char *catalog_id, const 
  * reference, or NULL when the member is absent or malformed. The caller must call json_decref. */
 json_t *catalog_extract_member(const char *text, const char *key);
 
+/* Collect the model ids the catalog knows under `catalog_id` (the cached snapshot) plus any
+ * catalog.models configuration under `provider_id` or `catalog_id`, deduplicated in written
+ * order. `count` receives the length; the caller frees each id and the array. NULL-safe. */
+char **catalog_list_model_ids(const char *provider_id, const char *catalog_id, size_t *count);
+
 /* Return whether cache writes replace the input charge. A known write rate below the input rate is
  * treated as a storage surcharge; unknown rates use the more common replacement policy. */
 int catalog_cache_write_replaces_input(const struct catalog_entry *entry);

--- a/src/config.c
+++ b/src/config.c
@@ -237,6 +237,19 @@ static const struct config_setting REGISTRY[] = {
     {.key = "providers.llamacpp.port", .env_var = "HAX_LLAMACPP_PORT", .default_value = "8080",
      .description = "Port for the local llama-server (when base_url is unset)",
      .kind = CONFIG_KIND_INT, .min = 1, .max = 65535},
+    /* Vertex AI Anthropic serving: only project and location are really required; access_token
+     * names an explicit token that skips the ADC file entirely. */
+    {.key = "providers.vertex.project", .env_var = "GOOGLE_CLOUD_PROJECT",
+     .env_var_alt = "ANTHROPIC_VERTEX_PROJECT_ID",
+     .description = "Google Cloud project id for Vertex AI (ANTHROPIC_VERTEX_PROJECT_ID also "
+                    "works)"},
+    {.key = "providers.vertex.location", .env_var = "GOOGLE_CLOUD_LOCATION",
+     .env_var_alt = "CLOUD_ML_REGION", .default_value = "us-east5",
+     .description = "Vertex AI location (default us-east5; `global`, `us`, or `eu` for the "
+                    "multi-region endpoints; CLOUD_ML_REGION also works)"},
+    {.key = "providers.vertex.access_token", .env_var = "GOOGLE_OAUTH_ACCESS_TOKEN", .secret = 1,
+     .description = "Explicit Google access token, bypassing the ADC file"},
+
     {.key = "providers.mock.script", .env_var = "HAX_MOCK_SCRIPT",
      .description = "Path to a mock-provider script (mock provider only)"},
 };
@@ -554,6 +567,8 @@ static const char *resolve_with_source(const char *key, int skip_empty, int skip
     } else {
         const char *conversation_value = object_get_string(store.conversation, key);
         const char *environment_value = setting ? getenv(setting->env_var) : NULL;
+        const char *alternate_value =
+            setting && setting->env_var_alt ? getenv(setting->env_var_alt) : NULL;
         const char *state_value = object_get_string(store.state, key);
         const char *file_value = object_get_string(store.file, key);
 
@@ -563,6 +578,9 @@ static const char *resolve_with_source(const char *key, int skip_empty, int skip
             value_source = "conversation";
         } else if (value_present(environment_value, skip_empty)) {
             value = environment_value;
+            value_source = "env";
+        } else if (value_present(alternate_value, skip_empty)) {
+            value = alternate_value;
             value_source = "env";
         } else if (value_present(state_value, skip_empty) &&
                    provider_binding_allows(store.state, key)) {

--- a/src/config.h
+++ b/src/config.h
@@ -177,6 +177,7 @@ enum config_kind {
 struct config_setting {
     const char *key;
     const char *env_var;
+    const char *env_var_alt; /* secondary fallback env var (enabled/home-dir secrets) */
     const char *default_value;
     const char *description;
     const char *choices; /* '|'-separated; exhaustive for strings, additive for numeric kinds */

--- a/src/providers/anthropic_body.c
+++ b/src/providers/anthropic_body.c
@@ -261,8 +261,13 @@ json_t *anthropic_build_body(const struct context *context, const char *provider
     json_t *messages =
         anthropic_build_messages(context->items, context->n_items, provider_id, model,
                                  opts->allow_empty_signature, context->image_input);
-    json_t *body = json_pack("{s:s, s:i, s:b, s:o}", "model", model, "max_tokens", opts->max_tokens,
-                             "stream", 1, "messages", messages);
+    json_t *body = json_pack("{s:i, s:b, s:o}", "max_tokens", opts->max_tokens, "stream", 1,
+                             "messages", messages);
+    if (!opts->omit_model)
+        json_object_set_new(body, "model", json_string(model));
+    /* Vertex raw-Predict: anthropic_version goes in the body, and there is no version header. */
+    if (opts->anthropic_version && *opts->anthropic_version)
+        json_object_set_new(body, "anthropic_version", json_string(opts->anthropic_version));
 
     if (context->system_prompt && *context->system_prompt) {
         json_t *system_block =

--- a/src/providers/http_provider.c
+++ b/src/providers/http_provider.c
@@ -1,12 +1,15 @@
 /* SPDX-License-Identifier: MIT */
 #include "providers/http_provider.h"
 
+#include <ctype.h>
 #include <fnmatch.h>
 #include <jansson.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
 
+#include "buf.h"
 #include "catalog.h"
 #include "config.h"
 #include "diag.h"
@@ -24,6 +27,7 @@
 #include "providers/wire.h"
 #include "text/placeholder.h"
 #include "text/url.h"
+#include "transport/api_error.h"
 #include "transport/http.h"
 
 #define MESSAGES_DEFAULT_VERSION    "2023-06-01"
@@ -56,7 +60,8 @@ struct http_provider {
     char *api_key;
     char *name;
     char *catalog_id;
-    char *endpoint; /* for the default wire; other wires derive theirs per request */
+    char *endpoint;     /* for the default wire; other wires derive theirs per request */
+    int path_has_model; /* endpoint carries a {model} placeholder, expanded per request */
     char *config_prefix;
     const struct wire *wire;          /* default; wire_rules and catalog hints override per model */
     const struct wire *metadata_wire; /* auth scheme for /models and probe requests */
@@ -73,6 +78,8 @@ struct http_provider {
     enum chat_reasoning_format reasoning_format;
     struct thinking_setting thinking; /* the def's; providers.<id>.thinking_mode overrides */
     int strict_signatures;
+    int body_version;     /* Messages: anthropic_version goes in the body, no version header */
+    int cache_default;    /* Messages cache_control default; chat uses cache_mode */
     char **extra_headers; /* "Name: value" templates; {session_id} expands per request */
     json_t *extra_body;
     struct http_auth_source auth; /* zeroed ops: the api_key authenticates requests */
@@ -82,6 +89,7 @@ struct http_provider {
     char *default_effort;
 
     const char *length_hint;    /* borrowed for the provider lifetime */
+    const char *payload_hint;   /* borrowed; appended to a request-too-large HTTP error */
     const char *const *efforts; /* borrowed, or aliases owned_efforts */
     const char **owned_efforts; /* owned array of borrowed strings; NULL when not narrowed */
     size_t n_efforts;
@@ -285,13 +293,43 @@ static int stream_auth_recover(void *ctx, long http_status, http_tick_cb tick, v
                                                tick, tick_user);
 }
 
+/* Whether `error_body` describes a request that exceeded the backend's payload cap, so a def's
+ * payload_hint can replace the cryptic "too large" message with an actionable one. Case-insensitive
+ * over the common phrasings (Google's "Request payload size exceeds the limit: N bytes"). */
+static int payload_too_large(const char *body)
+{
+    if (!body)
+        return 0;
+    size_t len = strlen(body);
+    if (len >= 4096)
+        len = 4095;
+    char lower[4096];
+    for (size_t i = 0; i < len; i++)
+        lower[i] = (char)tolower((unsigned char)body[i]);
+    lower[len] = '\0';
+    static const char *const NEEDLES[] = {"payload size", "too large", "request too large",
+                                          "payload limit"};
+    for (size_t i = 0; i < sizeof(NEEDLES) / sizeof(NEEDLES[0]); i++)
+        if (strstr(lower, NEEDLES[i]))
+            return 1;
+    return 0;
+}
+
 static char *stream_auth_error_message(void *ctx, long http_status, const char *error_body)
 {
-    (void)error_body;
     struct http_stream *stream = ctx;
-    if (http_status != 401)
-        return NULL;
-    return stream->provider->auth.ops->unauthorized_message(stream->provider->auth.state);
+    /* A rejected credential names the recovery step rather than the raw HTTP error. */
+    if (http_status == 401 && stream->provider->auth.ops)
+        return stream->provider->auth.ops->unauthorized_message(stream->provider->auth.state);
+    /* Vertex caps the request body at 30 MB; a long image-heavy session can hit that before the
+     * 1M-token window, and the error only says the request was too large. */
+    if (stream->provider->payload_hint && payload_too_large(error_body)) {
+        char *base = format_api_error(http_status, error_body);
+        char *combined = xasprintf("%s\n%s", base, stream->provider->payload_hint);
+        free(base);
+        return combined;
+    }
+    return NULL;
 }
 
 /* The wire `model` speaks: the first matching model_apis rule, else the catalog hint on a
@@ -335,6 +373,7 @@ static int request_reads_metadata(const struct http_provider *provider)
     return provider->catalog_wires || provider->n_wire_rules > 0 ||
            provider->wire != &WIRE_OPENAI_RESPONSES;
 }
+static char *model_expand_endpoint(const char *endpoint, const char *model);
 
 static int http_provider_stream(struct provider *base, const struct context *context,
                                 const char *model, stream_cb callback, void *callback_user,
@@ -392,6 +431,9 @@ static int http_provider_stream(struct provider *base, const struct context *con
         opts.thinking_budget = config_scoped_int(provider->config_prefix, "thinking_budget");
         opts.show_reasoning = config_bool("show_reasoning");
         opts.allow_empty_signature = !provider->strict_signatures;
+        /* Vertex raw-Predict reads the version from the body and drops the header. */
+        opts.omit_model = provider->body_version;
+        opts.anthropic_version = provider->body_version ? provider->version : NULL;
     } else {
         struct catalog_entry rates;
         model_meta_rates(base, model, &rates);
@@ -407,8 +449,13 @@ static int http_provider_stream(struct provider *base, const struct context *con
     if (!body)
         return -1;
 
-    char *endpoint =
-        wire == provider->wire ? NULL : xasprintf("%s%s", provider->base_url, wire->path);
+    char *endpoint = NULL;
+    if (wire == provider->wire) {
+        if (provider->path_has_model)
+            endpoint = model_expand_endpoint(provider->endpoint, model);
+    } else {
+        endpoint = xasprintf("%s%s", provider->base_url, wire->path);
+    }
     struct stream_retry request = {
         .endpoint = endpoint ? endpoint : provider->endpoint,
         .body = body,
@@ -424,6 +471,8 @@ static int http_provider_stream(struct provider *base, const struct context *con
     };
     if (provider->auth.ops) {
         request.recover = stream_auth_recover;
+        request.error_message = stream_auth_error_message;
+    } else if (provider->payload_hint) {
         request.error_message = stream_auth_error_message;
     }
     int result = stream_retry_run(&request, callback, callback_user, tick, tick_user);
@@ -609,6 +658,65 @@ static int def_base_url_port_templated(const struct provider_def *def)
     return def->base_url && placeholder_present(def->base_url, PORT_PLACEHOLDER);
 }
 
+/* Expand "{name}" placeholders in `template` into provider config values. "port" resolves through
+ * the typed providers.<id>.port (def default); any other name reads providers.<id>.<name> as a
+ * string. An unresolvable placeholder is dropped. Returns owned. */
+static char *expand_config_placeholders(const struct provider_def *def, const char *template)
+{
+    struct buf out;
+    buf_init(&out);
+    const char *rest = template;
+    while (*rest) {
+        const char *open = strstr(rest, "{");
+        if (!open) {
+            buf_append(&out, rest, strlen(rest));
+            break;
+        }
+        buf_append(&out, rest, (size_t)(open - rest));
+        const char *close = strchr(open, '}');
+        if (!close) {
+            buf_append(&out, open, strlen(open));
+            break;
+        }
+        const char *name = open + 1;
+        size_t name_len = (size_t)(close - name);
+        if (name_len == 4 && memcmp(name, "port", 4) == 0) {
+            char *key = xasprintf("providers.%s.port", def->id);
+            int port = config_int(key);
+            free(key);
+            if (port < 1 || port > 65535)
+                port = def->port;
+            if (port >= 1) {
+                char stack[32];
+                snprintf(stack, sizeof(stack), "%d", port);
+                buf_append(&out, stack, strlen(stack));
+            }
+        } else if (name_len == 5 && memcmp(name, "model", 5) == 0) {
+            /* {model} is resolved per request, not from config. */
+            buf_append(&out, open, (size_t)(close - open) + 1);
+        } else {
+            char *key = xasprintf("providers.%s.%.*s", def->id, (int)name_len, name);
+            const char *value = config_str_nonempty(key);
+            free(key);
+            if (value)
+                buf_append(&out, value, strlen(value));
+        }
+        rest = close + 1;
+    }
+    return buf_steal(&out);
+}
+
+/* Return the endpoint with {model} substituted for `model`, or NULL when `endpoint` carries no
+ * such placeholder. Owned. */
+static char *model_expand_endpoint(const char *endpoint, const char *model)
+{
+    const char *placeholder = strstr(endpoint, "{model}");
+    if (!placeholder)
+        return NULL;
+    return xasprintf("%.*s%s%s", (int)(placeholder - endpoint), endpoint, model,
+                     placeholder + strlen("{model}"));
+}
+
 /* Expand a "{port}" placeholder in a def's default base_url: providers.<name>.port, else the
  * def's own port. Returns the owned expansion, or NULL when the URL carries no placeholder or
  * no port resolves. */
@@ -633,28 +741,34 @@ static char *expand_port_template(const struct provider_def *def)
 }
 
 /* Resolve the def's endpoint: a pinned def's own base_url; otherwise the configured
- * providers.<id>.base_url verbatim, else the def's default with any "{port}" placeholder
- * expanded. Owned; NULL when nothing resolves. The trailing slash is trimmed so
- * "<base>/models" and "<base><wire path>" never double it. */
+ * providers.<id>.base_url verbatim, else the def's resolve_base_url hook, else the def's default
+ * with any "{port}" placeholder expanded. Owned; NULL when nothing resolves. The trailing slash
+ * is trimmed so "<base>/models" and "<base><wire path>" never double it. */
 static char *def_base_url(const struct provider_def *def)
 {
-    const char *base = def->base_url;
-    char *expanded = NULL;
-    if (!def->pinned) {
-        char *key = xasprintf("providers.%s.base_url", def->id);
-        const char *configured = config_str_nonempty(key);
-        free(key);
-        if (configured) {
-            base = configured;
-        } else {
-            expanded = expand_port_template(def);
-            if (expanded)
-                base = expanded;
-        }
+    if (def->pinned)
+        return def->base_url ? url_trim_trailing_slashes(def->base_url) : NULL;
+
+    char *key = xasprintf("providers.%s.base_url", def->id);
+    const char *configured = config_str_nonempty(key);
+    free(key);
+    if (configured)
+        return url_trim_trailing_slashes(configured);
+    if (def->resolve_base_url) {
+        char *resolved = def->resolve_base_url(def);
+        if (!resolved)
+            return NULL;
+        char *trimmed = url_trim_trailing_slashes(resolved);
+        free(resolved);
+        return trimmed;
     }
-    char *trimmed = base ? url_trim_trailing_slashes(base) : NULL;
-    free(expanded);
-    return trimmed;
+    char *expanded = expand_port_template(def);
+    if (expanded) {
+        char *trimmed = url_trim_trailing_slashes(expanded);
+        free(expanded);
+        return trimmed;
+    }
+    return def->base_url ? url_trim_trailing_slashes(def->base_url) : NULL;
 }
 
 void http_provider_availability(const struct provider_def *def, struct provider_availability *out)
@@ -690,6 +804,53 @@ void http_provider_availability(const struct provider_def *def, struct provider_
     }
     free(prefix);
     free(base);
+}
+
+/* A generic /model listing for endpoints that serve no /models route (Vertex), built entirely
+ * from the catalog: the ids it knows, enriched with their catalog metadata so the picker and
+ * autocomplete render context, cost, and effort without a network round trip. */
+int http_provider_list_catalog_models(struct provider *base, struct model_info **models,
+                                      size_t *n_models, char **error, http_tick_cb tick,
+                                      void *tick_user)
+{
+    (void)tick;
+    (void)tick_user;
+    const char *provider_id = provider_stable_id(base);
+    struct http_provider *provider = (struct http_provider *)base;
+    size_t count = 0;
+    char **ids = catalog_list_model_ids(provider_id, provider->catalog_id, &count);
+    if (!ids || count == 0) {
+        free(ids);
+        *models = NULL;
+        *n_models = 0;
+        *error = xasprintf("no catalog metadata for %s — the models.dev snapshot may be missing",
+                           provider->name);
+        return -1;
+    }
+
+    struct model_info *list = xcalloc(count, sizeof(*list));
+    for (size_t i = 0; i < count; i++) {
+        model_info_init(&list[i]);
+        list[i].id = ids[i]; /* transfer ownership */
+        struct catalog_entry entry;
+        if (catalog_lookup(provider_id, provider->catalog_id, ids[i], &entry) == 0) {
+            list[i].context = entry.context_window;
+            list[i].max_output = entry.max_output;
+            list[i].image_input = entry.image_input == CATALOG_SUPPORT_YES  ? PROVIDER_CAP_YES
+                                  : entry.image_input == CATALOG_SUPPORT_NO ? PROVIDER_CAP_NO
+                                                                            : PROVIDER_CAP_UNKNOWN;
+            list[i].cost_input = entry.cost_input;
+            list[i].cost_cache_read = entry.cost_cache_read;
+            list[i].cost_output = entry.cost_output;
+            list[i].cost_cache_write = entry.cost_cache_write;
+            list[i].cost_cache_write_1h = entry.cost_cache_write_1h;
+            list[i].efforts = entry.efforts;
+        }
+    }
+    free(ids);
+    *models = list;
+    *n_models = count;
+    return 0;
 }
 
 /* A declared <prefix>.model_apis block, valid members or not: routing intent makes the provider
@@ -907,7 +1068,15 @@ struct provider *http_provider_new(const struct provider_def *def)
     provider->name = xstrdup(resolve_display_name(def, prefix));
     provider->catalog_id = resolve_catalog_id(def, prefix);
     provider->wire = wire;
-    provider->endpoint = xasprintf("%s%s", provider->base_url, provider->wire->path);
+    /* A path template may carry config placeholders ({project}, {location}) resolved now and a
+     * {model} placeholder resolved per request. Non-template paths (wire's path) are literal. */
+    char *expanded_path = NULL;
+    if (def->path_template)
+        expanded_path = expand_config_placeholders(def, def->path_template);
+    const char *path = expanded_path ? expanded_path : wire->path;
+    provider->path_has_model = strstr(path, "{model}") != NULL;
+    provider->endpoint = xasprintf("%s%s", provider->base_url, path);
+    free(expanded_path);
     /* On the OpenAI side any OpenAI-family wire carries the same Bearer scheme; only a Messages
      * default wire paired with OpenAI-shaped metadata needs the explicit Chat stand-in. */
     if (metadata_api == HTTP_METADATA_ANTHROPIC)
@@ -926,7 +1095,9 @@ struct provider *http_provider_new(const struct provider_def *def)
                  provider->name);
     /* Resolved regardless of the default wire: per-model rules can route to Messages. */
     const char *version = config_scoped_str(prefix, "version");
-    provider->version = xstrdup(version && *version ? version : MESSAGES_DEFAULT_VERSION);
+    provider->version = xstrdup(
+        version && *version ? version : (def->version ? def->version : MESSAGES_DEFAULT_VERSION));
+    provider->body_version = def->body_version;
 
     provider->send_cache_key = config_scoped_bool_or(prefix, "send_cache_key", def->send_cache_key);
     provider->request_cost = config_scoped_bool_or(prefix, "request_cost", def->request_cost);
@@ -958,6 +1129,7 @@ struct provider *http_provider_new(const struct provider_def *def)
     }
 
     provider->length_hint = def->length_hint;
+    provider->payload_hint = def->payload_hint;
     /* Efforts are advisory offers narrowed by per-model metadata, so they default on; defs opt
      * out backends with no categorical effort. */
     if (!def->no_efforts) {

--- a/src/providers/http_provider.h
+++ b/src/providers/http_provider.h
@@ -81,6 +81,12 @@ const struct http_auth_source *http_provider_auth(const struct provider *provide
  * that authenticates successfully relaunches it. */
 void http_provider_defer_probe(struct provider *provider);
 
+/* Catalog-backed /model listing for defs whose endpoint serves no /models route: enumerates the
+ * provider's catalog models with their metadata, with no network round trip. */
+int http_provider_list_catalog_models(struct provider *base, struct model_info **models,
+                                      size_t *n_models, char **error, http_tick_cb tick,
+                                      void *tick_user);
+
 /* Output cap for one Messages request: <prefix>.max_tokens clamped to model metadata. */
 int http_provider_max_tokens(struct provider *provider, const char *model);
 

--- a/src/providers/registry.c
+++ b/src/providers/registry.c
@@ -20,6 +20,7 @@
 #include "providers/mock.h"
 #include "providers/opencode.h"
 #include "providers/openrouter.h"
+#include "providers/vertex.h"
 
 /* The OpenCode gateway pins a conversation to one upstream by its session header — Go rejects
  * requests without one — and attributes usage by client. */
@@ -113,6 +114,34 @@ static const struct provider_def DEFS[] = {
         .metadata_api = "openai",
         .extra_headers = OPENCODE_HEADERS,
         .query_usage = opencode_go_query_usage,
+    },
+    /* Vertex AI Anthropic serving. The endpoint carries project, location, and model in its URL
+     * (no /models route), needs a Google access token (never a static key, so an auth source),
+     * and reads anthropic_version from the body instead of the header. Host and path come from
+     * providers.vertex.{project,location}; an explicit base_url still wins verbatim. */
+    {
+        .id = "vertex",
+        .display_name = "Vertex AI",
+        .api = "anthropic-messages",
+        .version = "vertex-2023-10-16",
+        .body_version = 1,
+        /* Vertex signs and validates thinking blocks like the first-party Messages API. */
+        .strict_signatures = 1,
+        .cache = "on",
+        .thinking_mode = "adaptive",
+        .catalog_id = "google-vertex-anthropic",
+        .payload_hint = "vertex AI caps a request around 30 MB — trim context or images (or "
+                        "compact with /compact) before it fills",
+        /* No /models route: openai metadata stands in so the catalog list is installed and no
+         * probe launches. */
+        .metadata_api = "openai",
+        .path_template =
+            "/v1/projects/{project}/locations/{location}/publishers/anthropic/models/"
+            "{model}:streamRawPredict",
+        .auth_source = vertex_auth_source,
+        .resolve_base_url = vertex_resolve_base_url,
+        .list_models = http_provider_list_catalog_models,
+        .prepare_availability = vertex_prepare_availability,
     },
     /* Local servers. */
     {

--- a/src/providers/registry.h
+++ b/src/providers/registry.h
@@ -32,6 +32,14 @@ struct provider_def {
      * always used verbatim. */
     const char *base_url;
     int port; /* default for the "{port}" placeholder (0: none); providers.<id>.port overrides */
+    /* Per-request path override, added to the base URL in place of the wire's path. A template
+     * may carry {model} (substituted at request time) and providers.<id> config placeholders
+     * ({project}, {location}, {port}, ...; substituted at construction). NULL → the wire path. */
+    const char *path_template;
+    /* Resolve the endpoint's base URL from supplied config for defs whose host depends on a
+     * config value (e.g. a cloud per-region endpoint). Called only when no explicit base_url is
+     * configured; returns an owned URL or NULL after reporting why none can be derived. */
+    char *(*resolve_base_url)(const struct provider_def *def);
     /* First-party endpoint: configured base_url and api cannot rewire it, so its key is never
      * redirected to another host or protocol family. */
     int pinned;
@@ -56,8 +64,9 @@ struct provider_def {
     /* The endpoint signs and validates thinking blocks like the first-party Messages API, so
      * unsigned blocks from other backends are dropped rather than replayed and rejected. */
     int strict_signatures;
-    const char *length_hint; /* appended to a "length"-truncation error */
-    int no_efforts;          /* offer no effort levels, so /effort skips the provider */
+    const char *length_hint;  /* appended to a "length"-truncation error */
+    const char *payload_hint; /* appended to a request-too-large HTTP error */
+    int no_efforts;           /* offer no effort levels, so /effort skips the provider */
     /* JSON object of body members the endpoint requires on every request, merged under the
      * user's providers.<id>.extra_body. NULL sends none. */
     const char *extra_body;
@@ -65,6 +74,11 @@ struct provider_def {
      * user's providers.<id>.extra_headers; "{session_id}" in a value expands to the conversation's
      * affinity id. NULL sends none. */
     const char *extra_headers;
+    /* Default anthropic-version (body or header) when providers.<id>.version is unset. */
+    const char *version;
+    /* anthropic-messages: the endpoint reads anthropic_version from the body and drops the
+     * anthropic-version header (Vertex raw-Predict; `version` names the body value). */
+    int body_version;
     /* Probe <base_url>/models reachability when keyless. Only for curated local defs where
      * "not running" is the common failure and /models is known to exist; a generic endpoint may
      * not serve /models at all, so configuration is the default availability check. */

--- a/src/providers/vertex.c
+++ b/src/providers/vertex.c
@@ -1,0 +1,426 @@
+/* SPDX-License-Identifier: MIT */
+#include "providers/vertex.h"
+
+#include <ctype.h>
+#include <jansson.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include "buf.h"
+#include "config.h"
+#include "diag.h"
+#include "xalloc.h"
+#include "providers/http_provider.h"
+#include "system/fs.h"
+#include "system/path.h"
+#include "system/spawn.h"
+#include "transport/http.h"
+
+/* Vertex's Anthropic endpoint serves the Messages wire under a URL that carries the project,
+ * location, and model; see registry.c's def for the path template. Authentication is a Google
+ * access token sourced from user credentials — never a static API key. */
+
+#define VERTEX_OAUTH_URL "https://oauth2.googleapis.com/token"
+/* Instrumentation seam for tests: overrides the token endpoint (a fixed public URL would make
+ * the refresh flow untestable offline). */
+#define VERTEX_OAUTH_URL_ENV   "HAX_VERTEX_OAUTH_URL"
+#define VERTEX_TOKEN_MAX_BYTES (64 * 1024)
+#define VERTEX_TOKEN_TIMEOUT_S 10
+/* Refresh slightly early so an access token does not expire mid-request. */
+#define VERTEX_TOKEN_MARGIN_S 60
+/* Hobbling a SM service account needs no token; gcloud's print-access-token is fast, but a
+ * workload-identity federation call can take a moment, so bound it. */
+#define VERTEX_GCLOUD_TIMEOUT_MS 15000
+#define VERTEX_GCLOUD_MAX_BYTES  8192
+
+/* The default region mirrors Claude Code's CLOUD_ML_REGION default; users override it per
+ * deployment. The default and the CLOUD_ML_REGION fallback live in the config registry
+ * (providers.vertex.location) so the path template's {location} placeholder resolves from the
+ * same single source instead of a second, divergent lookup. */
+static const char *env_nonempty(const char *name)
+{
+    const char *value = getenv(name);
+    return value && *value ? value : NULL;
+}
+
+static const char *config_project(void)
+{
+    /* Registered as GOOGLE_CLOUD_PROJECT with ANTHROPIC_VERTEX_PROJECT_ID fallback. */
+    return config_str_nonempty("providers.vertex.project");
+}
+
+static const char *config_location(void)
+{
+    /* Registered as GOOGLE_CLOUD_LOCATION with CLOUD_ML_REGION fallback and a us-east5 default. */
+    return config_str_nonempty("providers.vertex.location");
+}
+
+static const char *config_literal_token(void)
+{
+    const char *token = config_str_nonempty("providers.vertex.access_token");
+    return token ? token : env_nonempty("GOOGLE_OAUTH_ACCESS_TOKEN");
+}
+
+char *vertex_resolve_base_url(const struct provider_def *def)
+{
+    (void)def;
+    const char *project = config_project();
+    const char *location = config_location();
+    if (!project) {
+        hax_err("provider 'vertex': providers.vertex.project is not set (or set "
+                "GOOGLE_CLOUD_PROJECT / ANTHROPIC_VERTEX_PROJECT_ID)");
+        return NULL;
+    }
+    const char *host;
+    char dynamic_host[128];
+    if (strcmp(location, "global") == 0) {
+        host = "aiplatform.googleapis.com";
+    } else if (strcmp(location, "us") == 0 || strcmp(location, "eu") == 0) {
+        /* Multi-region endpoints are served from the region's replica host. */
+        snprintf(dynamic_host, sizeof(dynamic_host), "aiplatform.%s.rep.googleapis.com", location);
+        host = dynamic_host;
+    } else {
+        snprintf(dynamic_host, sizeof(dynamic_host), "%s-aiplatform.googleapis.com", location);
+        host = dynamic_host;
+    }
+    return xasprintf("https://%s", host);
+}
+
+/* ---- credentials ----
+ *
+ * A session holds one access token plus the recipe to renew it. Resolution order mirrors what
+ * users already have configured: an explicit token (no refresh), the ADC file's authorized_user
+ * shape (refresh-token exchange), or any other ADC kind (shell out to gcloud — covering service
+ * accounts, workload identity federation, and impersonation without hand-rolling RS256). */
+
+enum vertex_auth_kind {
+    VERTEX_LITERAL, /* explicit token; rejected by 401 → re-read the literal once */
+    VERTEX_USER,    /* ADC authorized_user: OAuth refresh-token exchange */
+    VERTEX_SERVICE, /* other ADC kinds: `gcloud auth application-default print-access-token` */
+};
+
+struct vertex_auth {
+    enum vertex_auth_kind kind;
+    char *token;
+    time_t token_expires; /* 0 = no soft expiry */
+    /* user flow, read from the ADC file on each refresh so edits take effect */
+    char *client_id;
+    char *client_secret;
+    char *refresh_token;
+    /* Opened as logged-out with a blocking reason to report on the next request. */
+    char *fatal;
+};
+
+/* Percent-encode one byte for an application/x-www-form-urlencoded body. */
+static char *form_encode(const char *value)
+{
+    static const char hex[] = "0123456789ABCDEF";
+    struct buf out;
+    buf_init(&out);
+    for (const char *cursor = value; *cursor; cursor++) {
+        unsigned char byte = (unsigned char)*cursor;
+        if (('A' <= byte && byte <= 'Z') || ('a' <= byte && byte <= 'z') ||
+            ('0' <= byte && byte <= '9') || byte == '-' || byte == '_' || byte == '.' ||
+            byte == '~') {
+            buf_append(&out, cursor, 1);
+        } else {
+            char esc[3] = {'%', hex[byte >> 4], hex[byte & 0xF]};
+            buf_append(&out, esc, sizeof(esc));
+        }
+    }
+    return buf_steal(&out);
+}
+
+/* Default ADC path, or the configured GOOGLE_APPLICATION_CREDENTIALS. The caller must not free
+ * the result if it aliases the env. */
+static const char *adc_path(void)
+{
+    const char *configured = env_nonempty("GOOGLE_APPLICATION_CREDENTIALS");
+    static char *cached;
+    if (configured)
+        return configured;
+    if (!cached)
+        cached = path_expand_home("~/.config/gcloud/application_default_credentials.json");
+    return cached;
+}
+
+/* Read and parse the ADC file, or NULL when missing/invalid (caller frees with json_decref). */
+static json_t *load_adc(void)
+{
+    const char *path = adc_path();
+    if (!path || !*path)
+        return NULL;
+    char *contents = fs_read_file(path, NULL);
+    if (!contents)
+        return NULL;
+    json_t *root = json_loads(contents, 0, NULL);
+    free(contents);
+    return json_is_object(root) ? root : NULL;
+}
+
+/* Exchange the ADC file's own client_id/client_secret and refresh token for a new access token. */
+static int refresh_user_token(struct vertex_auth *a, char **detail)
+{
+    char *encoded_id = form_encode(a->client_id);
+    char *encoded_secret = form_encode(a->client_secret);
+    char *encoded_refresh = form_encode(a->refresh_token);
+    char *body = xasprintf("grant_type=refresh_token&client_id=%s&client_secret=%s"
+                           "&refresh_token=%s",
+                           encoded_id, encoded_secret, encoded_refresh);
+    free(encoded_id);
+    free(encoded_secret);
+    free(encoded_refresh);
+
+    const char *url = env_nonempty(VERTEX_OAUTH_URL_ENV);
+    const char *token_url = url ? url : VERTEX_OAUTH_URL;
+    char *response = NULL;
+    long status = 0;
+    int rc =
+        http_post(token_url, NULL, "application/x-www-form-urlencoded", body, strlen(body),
+                  VERTEX_TOKEN_TIMEOUT_S, VERTEX_TOKEN_MAX_BYTES, NULL, NULL, &response, &status);
+    free(body);
+    if (rc != 0 || status != 200 || !response) {
+        if (detail)
+            *detail = xstrdup("OAuth token refresh failed");
+        free(response);
+        return -1;
+    }
+    json_error_t json_error = {0};
+    json_t *root = json_loads(response, 0, &json_error);
+    free(response);
+    const char *token =
+        json_is_object(root) ? json_string_value(json_object_get(root, "access_token")) : NULL;
+    if (!token || !*token) {
+        json_decref(root);
+        if (detail)
+            *detail = xstrdup("OAuth token refresh returned no access_token");
+        return -1;
+    }
+    free(a->token);
+    a->token = xstrdup(token);
+    json_t *expires = json_object_get(root, "expires_in");
+    long ttl = json_is_number(expires) ? (long)json_integer_value(expires) : 0;
+    a->token_expires = ttl > 0 ? time(NULL) + ttl : 0;
+    json_decref(root);
+    return 0;
+}
+
+/* Have gcloud print an access token for whatever identity the ADC file describes (service
+ * account, workload identity federation, or impersonation). */
+static int refresh_service_token(struct vertex_auth *a, char **detail)
+{
+    static const char *const argv[] = {"gcloud", "auth", "application-default",
+                                       "print-access-token", NULL};
+    size_t length = 0;
+    char *output =
+        spawn_capture_stdout(argv, VERTEX_GCLOUD_MAX_BYTES, VERTEX_GCLOUD_TIMEOUT_MS, &length);
+    if (!output) {
+        if (detail)
+            *detail = xstrdup("`gcloud auth application-default print-access-token` failed");
+        return -1;
+    }
+    /* Strip the trailing newline gcloud emits. */
+    while (length > 0 && isspace((unsigned char)output[length - 1]))
+        output[--length] = '\0';
+    free(a->token);
+    a->token = xstrdup(output);
+    /* gcloud tokens are short-lived (~1h); treat them as expiring so a request refreshes rather
+     * than letting one die mid-turn. */
+    a->token_expires = time(NULL) + 3600 - VERTEX_TOKEN_MARGIN_S;
+    free(output);
+    return 0;
+}
+
+static void set_fatal(struct vertex_auth *a, const char *message)
+{
+    free(a->fatal);
+    a->fatal = xstrdup(message);
+}
+
+/* Classify what the current ADC file (or literal token) offers and load its long-lived secret
+ * material, leaving the short-lived token to a refresh. Reports none usable via `fatal`. */
+static int load_credentials(struct vertex_auth *a)
+{
+    free(a->fatal);
+    a->fatal = NULL;
+    const char *literal = config_literal_token();
+    if (literal) {
+        a->kind = VERTEX_LITERAL;
+        free(a->token);
+        a->token = xstrdup(literal);
+        a->token_expires = 0;
+        return 0;
+    }
+
+    json_t *root = load_adc();
+    if (!root) {
+        set_fatal(a, "no Google ADC credentials (run `gcloud auth application-default login`, "
+                     "or set GOOGLE_OAUTH_ACCESS_TOKEN)");
+        return -1;
+    }
+    const char *type = json_string_value(json_object_get(root, "type"));
+    const char *refresh = json_string_value(json_object_get(root, "refresh_token"));
+    if (type && strcmp(type, "authorized_user") == 0 && refresh && *refresh) {
+        const char *client_id = json_string_value(json_object_get(root, "client_id"));
+        const char *client_secret = json_string_value(json_object_get(root, "client_secret"));
+        if (client_id && *client_id && client_secret && *client_secret) {
+            a->kind = VERTEX_USER;
+            free(a->client_id);
+            free(a->client_secret);
+            free(a->refresh_token);
+            a->client_id = xstrdup(client_id);
+            a->client_secret = xstrdup(client_secret);
+            a->refresh_token = xstrdup(refresh);
+            json_decref(root);
+            return 0;
+        }
+        set_fatal(a, "Google ADC file has no usable refresh_token/client_id — rerun `gcloud "
+                     "auth application-default login`");
+        json_decref(root);
+        return -1;
+    }
+    json_decref(root);
+    /* Service-account and every other ADC shape: let gcloud print a token. */
+    a->kind = VERTEX_SERVICE;
+    return 0;
+}
+
+/* Bring a->token fresh. `force` skips the soft-expiry check (a rejected request). */
+static int verify_token(struct vertex_auth *a, int force)
+{
+    if (!a->token && a->fatal)
+        return -1;
+    if (!force && a->token && (a->token_expires == 0 || time(NULL) < a->token_expires))
+        return 0;
+
+    if (a->kind == VERTEX_LITERAL) {
+        /* A literal token has no soft expiry; only a 401 forces a re-read here. */
+        if (force)
+            return load_credentials(a);
+        return a->token ? 0 : -1;
+    }
+    /* Re-read the source before renewing so an edited ADC file takes effect. Losing the source is
+     * terminal (the user changed something mid-session). */
+    if (load_credentials(a) != 0)
+        return -1;
+    char *detail = NULL;
+    int rc =
+        a->kind == VERTEX_USER ? refresh_user_token(a, &detail) : refresh_service_token(a, &detail);
+    if (rc != 0) {
+        set_fatal(a, detail ? detail : "Google credential refresh failed");
+        free(detail);
+        return -1;
+    }
+    return 0;
+}
+
+static int vertex_auth_prepare(void *auth, int allow_refresh, http_tick_cb tick, void *tick_user)
+{
+    (void)tick;
+    (void)tick_user;
+    struct vertex_auth *a = auth;
+    if (!a->token) {
+        if (load_credentials(a) != 0)
+            return -1;
+        return verify_token(a, 0) == 0 ? 0 : -1;
+    }
+    if (a->kind != VERTEX_LITERAL && a->token_expires > 0 && allow_refresh &&
+        time(NULL) >= a->token_expires)
+        return verify_token(a, 1) == 0 ? 0 : -1;
+    return 0;
+}
+
+static char **vertex_auth_headers(const void *auth, const char *session_id, int streaming)
+{
+    (void)session_id;
+    (void)streaming;
+    const struct vertex_auth *a = auth;
+    char *authorization = xasprintf("Authorization: Bearer %s", a->token ? a->token : "");
+    const char *fixed[] = {authorization, NULL};
+    char **headers = string_array_concat(fixed, NULL);
+    free(authorization);
+    return headers;
+}
+
+/* One forced renewal after a 401. */
+static int vertex_auth_recover(void *auth, int *retried, http_tick_cb tick, void *tick_user)
+{
+    (void)tick;
+    (void)tick_user;
+    struct vertex_auth *a = auth;
+    if (*retried)
+        return 0;
+    *retried = 1;
+    if (verify_token(a, 1) == 0)
+        return 1;
+    free(a->token);
+    a->token = NULL;
+    return 0;
+}
+
+static char *vertex_auth_unauthorized_message(void *auth)
+{
+    struct vertex_auth *a = auth;
+    if (!a->token && a->fatal)
+        return xstrdup(a->fatal);
+    return xstrdup("Google rejected the access token — run `gcloud auth application-default "
+                   "login`, or check GOOGLE_OAUTH_ACCESS_TOKEN");
+}
+
+static void vertex_auth_clear(struct vertex_auth *a)
+{
+    free(a->token);
+    free(a->client_id);
+    free(a->client_secret);
+    free(a->refresh_token);
+    free(a->fatal);
+}
+
+static void vertex_auth_destroy(void *auth)
+{
+    struct vertex_auth *a = auth;
+    vertex_auth_clear(a);
+    free(a);
+}
+
+static const struct http_auth_ops VERTEX_AUTH_OPS = {
+    .prepare = vertex_auth_prepare,
+    .headers = vertex_auth_headers,
+    .recover = vertex_auth_recover,
+    .unauthorized_message = vertex_auth_unauthorized_message,
+    .destroy = vertex_auth_destroy,
+};
+
+int vertex_auth_source(const struct provider_def *def, struct http_auth_source *out)
+{
+    (void)def;
+    struct vertex_auth *a = xcalloc(1, sizeof(*a));
+    /* A missing credential source does not fail construction: the session reports the resolution
+     * steps on the first request and on availability. */
+    load_credentials(a);
+    out->ops = &VERTEX_AUTH_OPS;
+    out->state = a;
+    return 0;
+}
+
+void vertex_prepare_availability(const struct provider_def *def, struct provider_availability *out)
+{
+    (void)def;
+    memset(out, 0, sizeof(*out));
+    if (!config_project()) {
+        out->available = 0;
+        out->reason = xstrdup("providers.vertex.project not set (or GOOGLE_CLOUD_PROJECT / "
+                              "ANTHROPIC_VERTEX_PROJECT_ID)");
+        return;
+    }
+    struct vertex_auth a = {0};
+    if (load_credentials(&a) != 0) {
+        out->available = 0;
+        out->reason = xstrdup(a.fatal ? a.fatal : "no Google credentials");
+    } else {
+        out->available = 1;
+    }
+    vertex_auth_clear(&a);
+}

--- a/src/providers/vertex.h
+++ b/src/providers/vertex.h
@@ -1,0 +1,24 @@
+/* SPDX-License-Identifier: MIT */
+#ifndef HAX_PROVIDERS_VERTEX_H
+#define HAX_PROVIDERS_VERTEX_H
+
+struct provider_availability; /* provider.h */
+struct provider_def;          /* providers/registry.h */
+struct http_auth_source;      /* providers/http_provider.h */
+
+/* Auth-source hook for the vertex def: open a Google-credential session as `out`'s state. A
+ * missing or broken credential source does not fail construction — the session reports the
+ * resolution steps on the first request and on availability. The session re-reads the ADC file
+ * and refreshes short-lived access tokens across the session's lifetime. */
+int vertex_auth_source(const struct provider_def *def, struct http_auth_source *out);
+
+/* Resolve the endpoint's base URL (scheme + host) from the resolved project and location: the
+ * `global` endpoint, the us/eu multi-region endpoints, or the per-location regional host. Returns
+ * an owned URL, or NULL after reporting which value is missing. */
+char *vertex_resolve_base_url(const struct provider_def *def);
+
+/* Immediate availability verdict for the picker: project/location plus usable credentials, with
+ * no network probe. */
+void vertex_prepare_availability(const struct provider_def *def, struct provider_availability *out);
+
+#endif /* HAX_PROVIDERS_VERTEX_H */

--- a/src/providers/wire.h
+++ b/src/providers/wire.h
@@ -47,6 +47,12 @@ struct wire_body_opts {
     int thinking_budget;       /* tokens; out-of-range values fall back to max_tokens - 1 */
     int show_reasoning;        /* adaptive thinking: summarized display instead of omitted */
     int allow_empty_signature; /* preserve unsigned thinking blocks on compat backends */
+    /* Vertex raw-Predict contract: the endpoint reads `anthropic_version` from the body and names
+     * the model in its URL. `omit_model` drops the model member, and `anthropic_version` (borrowed,
+     * e.g. "vertex-2023-10-16") is sent as the body's anthropic_version member instead of the
+     * anthropic-version header. */
+    int omit_model;
+    const char *anthropic_version;
 };
 
 struct wire {

--- a/tests/e2e/test_vertex.py
+++ b/tests/e2e/test_vertex.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Vertex AI provider: a loopback Anthropic SSE server stands in for the raw-predict endpoint,
+and a one-shot run drives the full path (auth bearer, project/location/model URL, body variant)
+to completion."""
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import harness
+
+SSE_RESPONSE = "\n".join(
+    [
+        # data: lines frame the stream; the anthropic wire dispatches on the JSON "type".
+        'data: {"type":"message_start","message":{"id":"msg_smoke","type":"message",'
+        '"role":"assistant","model":"claude-sonnet-4-5@20250929","content":[],'
+        '"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":3,"output_tokens":0}}}',
+        "",
+        'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}',
+        "",
+        'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta",'
+        '"text":"Hello from vertex"}}',
+        "",
+        'data: {"type":"content_block_stop","index":0}',
+        "",
+        'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},'
+        '"usage":{"output_tokens":3}}',
+        "",
+        'data: {"type":"message_stop"}',
+        "",
+    ]
+)
+
+
+class VertexHandler(BaseHTTPRequestHandler):
+    request_path = ""
+    request_auth = ""
+
+    def do_POST(self):  # noqa: N802 (BaseHTTPRequestHandler API)
+        type(self).request_path = self.path
+        type(self).request_auth = self.headers.get("Authorization", "")
+        body = self.rfile.read(
+            int(self.headers.get("Content-Length", 0))
+        )
+        self.server.request_body = body
+        payload = (
+            "HTTP/1.1 200 OK\r\n"
+            "Content-Type: text/event-stream\r\n"
+            "Connection: close\r\n"
+            f"Content-Length: {len(SSE_RESPONSE)}\r\n"
+            "\r\n"
+        )
+        self.wfile.write(payload.encode("utf-8"))
+        self.wfile.write(SSE_RESPONSE.encode("utf-8"))
+        self.wfile.flush()
+
+    def log_message(self, *args):  # silence the default stderr logging
+        pass
+
+
+def main() -> None:
+    server = ThreadingHTTPServer(("127.0.0.1", 0), VertexHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    base_url = f"http://127.0.0.1:{server.server_address[1]}"
+    model = "claude-sonnet-4-5@20250929"
+
+    home, workdir = harness.make_home()
+    xdg_config = home / ".config"
+    xdg_config.mkdir()
+    (xdg_config / "hax").mkdir()
+    (xdg_config / "hax" / "config.json").write_text(
+        json.dumps(
+            {
+                "model": model,
+                "providers": {
+                    "vertex": {"base_url": base_url, "project": "smoke-proj", "location": "us"}
+                },
+            }
+        )
+    )
+
+    env = harness.hermetic_env(home)
+    env["GOOGLE_OAUTH_ACCESS_TOKEN"] = "smoke-token"
+    env["XDG_CONFIG_HOME"] = str(xdg_config)
+
+    import subprocess
+
+    proc = subprocess.run(
+        [str(harness.hax_binary()), "-p", "--provider=vertex", "hi"],
+        cwd=workdir,
+        env=env,
+        capture_output=True,
+        encoding="utf-8",
+        timeout=30,
+    )
+    result = harness.Result(proc, workdir)
+    server.shutdown()
+    server.server_close()
+
+    harness.expect(result.returncode == 0, "vertex one-shot exits 0", result)
+    harness.expect("Hello from vertex" in result.stdout, "streamed text reaches stdout", result)
+    # The full raw-predict URL with the model in the path (the @version model id intact).
+    harness.expect(
+        VertexHandler.request_path
+        == f"/v1/projects/smoke-proj/locations/us/publishers/anthropic/models/{model}:"
+        f"streamRawPredict",
+        "endpoint URL carries project/location/model",
+        result,
+    )
+    harness.expect(
+        VertexHandler.request_auth == "Bearer smoke-token",
+        "request authenticates with the Google bearer token",
+        result,
+    )
+    request_body = getattr(server, "request_body", b"")
+    request_json = json.loads(request_body or b"{}")
+    harness.expect(
+        "model" not in request_json, "raw-predict body carries no model member", result
+    )
+    harness.expect(
+        request_json.get("anthropic_version") == "vertex-2023-10-16",
+        "anthropic_version lives in the body",
+        result,
+    )
+    harness.expect(
+        request_json.get("max_tokens", 0) > 0, "max_tokens is present", result
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -66,6 +66,7 @@ test_sources = [
     'providers/test_responses_body.c',
     'providers/test_responses_events.c',
     'providers/test_stream_retry.c',
+    'providers/test_vertex.c',
     'providers/test_wire.c',
 
     'render/test_ctrl_strip.c',
@@ -154,6 +155,7 @@ e2e_scenarios = [
     'oneshot_signal_interrupt',
     'oneshot_text',
     'oneshot_tool',
+    'vertex',
 ]
 
 python = find_program('python3')

--- a/tests/providers/test_http_provider.c
+++ b/tests/providers/test_http_provider.c
@@ -659,6 +659,55 @@ static void test_auth_source_logged_out(void)
     provider->destroy(provider);
 }
 
+/* A payload_hint def appends an actionable line when the endpoint rejects a request as too
+ * large; unrelated error bodies keep the default message. */
+static void test_payload_hint(void)
+{
+    const char *body = "{\"error\": {\"code\": 400, \"message\": \"Request payload size exceeds "
+                       "the limit: 31457280 bytes\", \"status\": \"INVALID_ARGUMENT\"}}";
+    char *response =
+        xasprintf("HTTP/1.1 400 Bad Request\r\nContent-Length: %zu\r\nConnection: close\r\n\r\n%s",
+                  strlen(body), body);
+    struct wire_server server = {
+        .response = response,
+        .n_requests = 1,
+    };
+    pthread_t thread;
+    int port = start_server(&server, &thread);
+    EXPECT(port > 0);
+    if (port <= 0) {
+        free(response);
+        return;
+    }
+
+    char base_url[64];
+    snprintf(base_url, sizeof(base_url), "http://127.0.0.1:%d", port);
+    struct provider_def def = {
+        .id = "pl",
+        .base_url = base_url,
+        .payload_hint = "payload hint line",
+    };
+    struct provider *provider = http_provider_new(&def);
+    EXPECT(provider != NULL);
+    if (!provider) {
+        free(response);
+        return;
+    }
+
+    struct item items[] = {{.kind = ITEM_USER_MESSAGE, .text = "hello"}};
+    struct context context = {.items = items, .n_items = 1, .image_input = 1};
+    struct error_log log = {0};
+    provider->stream(provider, &context, "m", log_error, &log, NULL, NULL);
+    pthread_join(thread, NULL);
+    close(server.listener_fd);
+    EXPECT(atomic_load(&server.served) == 1);
+    EXPECT(log.n_errors == 1);
+    EXPECT(strstr(log.message, "payload size exceeds") != NULL);
+    EXPECT(strstr(log.message, "payload hint line") != NULL);
+    provider->destroy(provider);
+    free(response);
+}
+
 static void fake_load_defaults(char **default_model, char **default_effort)
 {
     *default_model = xstrdup("companion-model");
@@ -982,6 +1031,7 @@ int main(void)
     test_messages_defaults_follow_def();
     test_auth_source_stream();
     test_auth_source_logged_out();
+    test_payload_hint();
     test_def_extra_body_and_defaults();
     test_def_extra_headers_follow_conversation();
     test_interleaved_reasoning_replay();

--- a/tests/providers/test_vertex.c
+++ b/tests/providers/test_vertex.c
@@ -1,0 +1,427 @@
+/* SPDX-License-Identifier: MIT */
+#include <errno.h>
+#include <jansson.h>
+#include <poll.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+#include "config.h"
+#include "diag.h"
+#include "harness.h"
+#include "provider.h"
+#include "xalloc.h"
+#include "providers/anthropic_body.h"
+#include "providers/http_provider.h"
+#include "providers/registry.h"
+#include "providers/vertex.h"
+#include "providers/wire.h"
+
+/* Endpoint host follows the resolved location: `global`, a `us`/`eu` multi-region, or the
+ * regional host. An explicit base_url would win verbatim instead. */
+static void test_resolve_base_url_host_rules(void)
+{
+    /* Host env leaking in would override the registry defaults the test leans on. */
+    unsetenv("GOOGLE_CLOUD_PROJECT");
+    unsetenv("ANTHROPIC_VERTEX_PROJECT_ID");
+    unsetenv("GOOGLE_CLOUD_LOCATION");
+    unsetenv("CLOUD_ML_REGION");
+    EXPECT(config_load("{\"providers\": {\"vertex\": {\"project\": \"proj-1\","
+                       " \"location\": \"global\"}}}") == 0);
+    char *url = vertex_resolve_base_url(NULL);
+    EXPECT_STR_EQ(url, "https://aiplatform.googleapis.com");
+    free(url);
+
+    EXPECT(config_load("{\"providers\": {\"vertex\": {\"project\": \"proj-1\","
+                       " \"location\": \"us\"}}}") == 0);
+    url = vertex_resolve_base_url(NULL);
+    EXPECT_STR_EQ(url, "https://aiplatform.us.rep.googleapis.com");
+    free(url);
+
+    EXPECT(config_load("{\"providers\": {\"vertex\": {\"project\": \"proj-1\","
+                       " \"location\": \"eu\"}}}") == 0);
+    url = vertex_resolve_base_url(NULL);
+    EXPECT_STR_EQ(url, "https://aiplatform.eu.rep.googleapis.com");
+    free(url);
+
+    EXPECT(config_load("{\"providers\": {\"vertex\": {\"project\": \"proj-1\","
+                       " \"location\": \"us-central1\"}}}") == 0);
+    url = vertex_resolve_base_url(NULL);
+    EXPECT_STR_EQ(url, "https://us-central1-aiplatform.googleapis.com");
+    free(url);
+
+    /* The default location fills in when none is set. */
+    EXPECT(config_load("{\"providers\": {\"vertex\": {\"project\": \"proj-1\"}}}") == 0);
+    url = vertex_resolve_base_url(NULL);
+    EXPECT_STR_EQ(url, "https://us-east5-aiplatform.googleapis.com");
+    free(url);
+
+    /* Missing project fails with a diagnostic, so availability and construction report it. */
+    EXPECT(config_load("{ }") == 0);
+    unsigned long diagnostics_before = hax_diag_sequence();
+    url = vertex_resolve_base_url(NULL);
+    EXPECT(url == NULL);
+    EXPECT(hax_diag_sequence() == diagnostics_before + 1);
+    EXPECT(config_load(NULL) == 0);
+}
+
+static int idx_of(const char *name)
+{
+    size_t n;
+    const struct provider_def *const *all = provider_all(&n);
+    for (size_t i = 0; i < n; i++)
+        if (strcmp(all[i]->id, name) == 0)
+            return (int)i;
+    return -1;
+}
+
+/* vertex is a data def in autoselect order, below the gateways and above the local servers. */
+static void test_def_registered(void)
+{
+    const struct provider_def *def = provider_find("vertex");
+    EXPECT(def != NULL);
+    if (!def)
+        return;
+    EXPECT_STR_EQ(def->display_name, "Vertex AI");
+    EXPECT_STR_EQ(def->api, "anthropic-messages");
+    EXPECT_STR_EQ(def->catalog_id, "google-vertex-anthropic");
+    EXPECT_STR_EQ(def->version, "vertex-2023-10-16");
+    EXPECT(def->body_version == 1);
+    EXPECT(def->strict_signatures == 1);
+    EXPECT(def->auth_source == vertex_auth_source);
+    EXPECT(def->resolve_base_url == vertex_resolve_base_url);
+    EXPECT(def->list_models == http_provider_list_catalog_models);
+    EXPECT(strstr(def->path_template, "{model}") != NULL);
+    EXPECT(strstr(def->path_template, "{project}") != NULL);
+    EXPECT(strstr(def->path_template, "{location}") != NULL);
+
+    EXPECT(idx_of("vertex") > idx_of("opencode-go"));
+    EXPECT(idx_of("vertex") < idx_of("llamacpp"));
+    EXPECT(provider_default() == provider_find("codex"));
+}
+
+/* The bare Messages wire carries the model and the version header; the Vertex raw-Predict
+ * variant drops the model member and puts anthropic_version in the body. */
+static void test_messages_body_variant(void)
+{
+    struct item items[] = {{.kind = ITEM_USER_MESSAGE, .text = "hello"}};
+    struct context context = {.items = items, .n_items = 1, .image_input = 1};
+    struct wire_body_opts opts = {
+        .max_tokens = 32000, .anthropic_version = "vertex-2023-10-16", .omit_model = 1};
+    json_t *body = anthropic_build_body(&context, "vertex", "claude-x", &opts);
+    EXPECT(json_object_get(body, "model") == NULL);
+    EXPECT_STR_EQ(json_string_value(json_object_get(body, "anthropic_version")),
+                  "vertex-2023-10-16");
+    json_decref(body);
+
+    struct wire_body_opts default_opts = {.max_tokens = 32000};
+    body = anthropic_build_body(&context, "vertex", "claude-x", &default_opts);
+    EXPECT_STR_EQ(json_string_value(json_object_get(body, "model")), "claude-x");
+    EXPECT(json_object_get(body, "anthropic_version") == NULL);
+    json_decref(body);
+}
+
+/* One sequential-connection server echoing a canned reply; captures each request. */
+struct wire_server {
+    int listener_fd;
+    const char *response;
+    int n_requests;
+    char requests[8][8192];
+    _Atomic int served;
+};
+
+static void *serve_requests(void *user)
+{
+    struct wire_server *server = user;
+    for (int i = 0; i < server->n_requests; i++) {
+        struct pollfd poll_fd = {.fd = server->listener_fd, .events = POLLIN};
+        if (poll(&poll_fd, 1, 10000) <= 0)
+            return NULL;
+        int client_fd = accept(server->listener_fd, NULL, NULL);
+        if (client_fd < 0)
+            return NULL;
+        char *request = server->requests[i];
+        size_t request_len = 0;
+        size_t expected_len = 0;
+        while (request_len < sizeof(server->requests[i]) - 1) {
+            ssize_t bytes_read = read(client_fd, request + request_len,
+                                      sizeof(server->requests[i]) - request_len - 1);
+            if (bytes_read <= 0)
+                break;
+            request_len += (size_t)bytes_read;
+            request[request_len] = '\0';
+            char *header_end = strstr(request, "\r\n\r\n");
+            if (header_end && expected_len == 0) {
+                const char *length = strstr(request, "Content-Length: ");
+                expected_len = (size_t)(header_end + 4 - request) +
+                               (length ? strtoul(length + 16, NULL, 10) : 0);
+            }
+            if (expected_len > 0 && request_len >= expected_len)
+                break;
+        }
+        const char *response = server->response;
+        size_t response_len = strlen(response);
+        size_t written = 0;
+        while (written < response_len) {
+            ssize_t result = write(client_fd, response + written, response_len - written);
+            if (result <= 0)
+                break;
+            written += (size_t)result;
+        }
+        close(client_fd);
+        atomic_fetch_add(&server->served, 1);
+    }
+    return NULL;
+}
+
+static int start_server(struct wire_server *server, pthread_t *thread)
+{
+    server->listener_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (server->listener_fd < 0)
+        return -1;
+    struct sockaddr_in address = {0};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (bind(server->listener_fd, (struct sockaddr *)&address, sizeof(address)) != 0 ||
+        listen(server->listener_fd, 8) != 0)
+        goto error;
+    socklen_t address_len = sizeof(address);
+    if (getsockname(server->listener_fd, (struct sockaddr *)&address, &address_len) != 0)
+        goto error;
+    if (pthread_create(thread, NULL, serve_requests, server) != 0)
+        goto error;
+    return ntohs(address.sin_port);
+error:
+    close(server->listener_fd);
+    server->listener_fd = -1;
+    return -1;
+}
+
+struct error_log {
+    int n_errors;
+    char message[256];
+};
+
+static int log_error(const struct stream_event *event, void *user)
+{
+    struct error_log *log = user;
+    if (event->kind == EV_ERROR) {
+        log->n_errors++;
+        snprintf(log->message, sizeof(log->message), "%s", event->u.error.message);
+    }
+    return 0;
+}
+
+/* End-to-end: an explicit base_url wins verbatim, the path template expands project/location
+ * now and the model per request, auth is a Google bearer, and the body is the raw-Predict shape
+ * (no model member, anthropic_version in the body, no anthropic-version header). */
+static void test_stream_raw_predict(void)
+{
+    struct wire_server server = {
+        .response = "HTTP/1.1 400 Bad Request\r\nContent-Length: 2\r\nConnection: close\r\n\r\nno",
+        .n_requests = 1,
+    };
+    pthread_t thread;
+    int port = start_server(&server, &thread);
+    EXPECT(port > 0);
+    if (port <= 0)
+        return;
+
+    char base_url[64];
+    snprintf(base_url, sizeof(base_url), "http://127.0.0.1:%d", port);
+    char *config_json = xasprintf("{\"providers\": {\"vertex\": {\"base_url\": \"%s\","
+                                  " \"project\": \"proj-1\", \"location\": \"us-east5\","
+                                  " \"access_token\": \"gcp-tok\"}}}",
+                                  base_url);
+    EXPECT(config_load(config_json) == 0);
+    free(config_json);
+    const struct provider_def *def = provider_find("vertex");
+    struct provider *provider = provider_construct(def);
+    EXPECT(provider != NULL);
+    if (!provider)
+        return;
+
+    struct item items[] = {{.kind = ITEM_USER_MESSAGE, .text = "hello"}};
+    struct context context = {.items = items, .n_items = 1, .image_input = 1};
+    struct error_log log = {0};
+    const char *model = "claude-sonnet@20250929";
+    provider->stream(provider, &context, model, log_error, &log, NULL, NULL);
+    pthread_join(thread, NULL);
+    close(server.listener_fd);
+    EXPECT(atomic_load(&server.served) == 1);
+    EXPECT(log.n_errors == 1);
+    EXPECT(strstr(server.requests[0], "POST /v1/projects/proj-1/locations/us-east5/"
+                                      "publishers/anthropic/models/claude-sonnet@20250929:"
+                                      "streamRawPredict HTTP") != NULL);
+    EXPECT(strstr(server.requests[0], "Authorization: Bearer gcp-tok\r\n") != NULL);
+    /* Vertex reads the version from the body, not the anthropic-version header. */
+    EXPECT(strstr(server.requests[0], "anthropic-version:") == NULL);
+    EXPECT(strstr(server.requests[0], "\"anthropic_version\":\"vertex-2023-10-16\"") != NULL);
+    EXPECT(strstr(server.requests[0], "\"model\":") == NULL);
+
+    provider->destroy(provider);
+    EXPECT(config_load(NULL) == 0);
+}
+
+/* A minimal HTTP body that reads the request and returns a canned response; used to stand in for
+ * the OAuth token endpoint. */
+struct oauth_server {
+    int listener_fd;
+    const char *response;
+    int n_requests;
+    char request[8192];
+    _Atomic int served;
+};
+
+static void *serve_oauth(void *user)
+{
+    struct oauth_server *server = user;
+    for (int i = 0; i < server->n_requests; i++) {
+        struct pollfd poll_fd = {.fd = server->listener_fd, .events = POLLIN};
+        if (poll(&poll_fd, 1, 10000) <= 0)
+            return NULL;
+        int client_fd = accept(server->listener_fd, NULL, NULL);
+        if (client_fd < 0)
+            return NULL;
+        ssize_t bytes = read(client_fd, server->request, sizeof(server->request) - 1);
+        if (bytes > 0)
+            server->request[bytes] = '\0';
+        const char *response = server->response;
+        dprintf(client_fd, "HTTP/1.1 200 OK\r\nContent-Length: %zu\r\nConnection: close\r\n\r\n%s",
+                strlen(response), response);
+        close(client_fd);
+        atomic_fetch_add(&server->served, 1);
+    }
+    return NULL;
+}
+
+static int start_oauth_server(struct oauth_server *server, pthread_t *thread, const char *response)
+{
+    server->response = response;
+    server->listener_fd = socket(AF_INET, SOCK_STREAM, 0);
+    if (server->listener_fd < 0)
+        return -1;
+    struct sockaddr_in address = {0};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    if (bind(server->listener_fd, (struct sockaddr *)&address, sizeof(address)) != 0 ||
+        listen(server->listener_fd, 2) != 0)
+        goto error;
+    socklen_t address_len = sizeof(address);
+    if (getsockname(server->listener_fd, (struct sockaddr *)&address, &address_len) != 0)
+        goto error;
+    if (pthread_create(thread, NULL, serve_oauth, server) != 0)
+        goto error;
+    return ntohs(address.sin_port);
+error:
+    close(server->listener_fd);
+    server->listener_fd = -1;
+    return -1;
+}
+
+/* Write a fresh authorized_user ADC file into a temp dir and hand the path out via
+ * GOOGLE_APPLICATION_CREDENTIALS. */
+static void write_adc_user_file(const char *refresh_token)
+{
+    char *dir = t_tempdir();
+    char *path = xasprintf("%s/adc.json", dir);
+    FILE *f = fopen(path, "w");
+    if (!f)
+        FAIL("fopen %s: %s", path, strerror(errno));
+    fputs("{\"type\": \"authorized_user\","
+          "\"client_id\": \"cid\","
+          "\"client_secret\": \"csecret\","
+          "\"refresh_token\": \"",
+          f);
+    fputs(refresh_token, f);
+    fputs("\"}", f);
+    fclose(f);
+    setenv("GOOGLE_APPLICATION_CREDENTIALS", path, 1);
+    free(path);
+}
+
+/* Prompt-less auth through an authorized_user ADC file: a 401 to one crafted to expiring
+ * credentials recovers by refreshing against the (overridable) token endpoint, and the rebuilt
+ * request carries the new token. */
+static void test_auth_source_user_refresh(void)
+{
+    struct oauth_server oauth = {.n_requests = 2};
+    char oauth_url[64];
+    pthread_t oauth_thread;
+    int oauth_port = start_oauth_server(&oauth, &oauth_thread,
+                                        "{\"access_token\": \"fresh-2\", \"expires_in\": 3600}");
+    EXPECT(oauth_port > 0);
+    if (oauth_port <= 0)
+        return;
+    snprintf(oauth_url, sizeof(oauth_url), "http://127.0.0.1:%d", oauth_port);
+    setenv("HAX_VERTEX_OAUTH_URL", oauth_url, 1);
+
+    write_adc_user_file("old-refresh");
+
+    struct http_auth_source source = {0};
+    EXPECT(vertex_auth_source(NULL, &source) == 0);
+    /* First call has no token: prepare runs the refresh exchange. */
+    EXPECT(source.ops->prepare(source.state, 1, NULL, NULL) == 0);
+    char **headers = source.ops->headers(source.state, "sid", 1);
+    EXPECT(strstr(headers[0], "Authorization: Bearer fresh-2") != NULL);
+    string_array_free(headers);
+
+    /* A logged-out/rejected state recovers by forcing one refresh against the endpoint. */
+    int retried = 0;
+    EXPECT(source.ops->recover(source.state, &retried, NULL, NULL) == 1);
+    EXPECT(retried == 1);
+    char *message = source.ops->unauthorized_message(source.state);
+    EXPECT(strstr(message, "gcloud auth application-default login") != NULL);
+    free(message);
+
+    pthread_join(oauth_thread, NULL);
+    close(oauth.listener_fd);
+    EXPECT(atomic_load(&oauth.served) == 2);
+    /* The refresh is a form POST carrying the ADC's own refresh token. */
+    EXPECT(strstr(oauth.request, "grant_type=refresh_token") != NULL);
+    EXPECT(strstr(oauth.request, "refresh_token=old-refresh") != NULL);
+
+    source.ops->destroy(source.state);
+    unsetenv("HAX_VERTEX_OAUTH_URL");
+    unsetenv("GOOGLE_APPLICATION_CREDENTIALS");
+}
+
+/* A missing credential source never blocks construction: the session reports the resolution
+ * step on the first request and on availability. */
+static void test_auth_source_literal(void)
+{
+    EXPECT(config_load("{\"providers\": {\"vertex\": {\"project\": \"proj\","
+                       " \"access_token\": \"lit-tok\"}}}") == 0);
+    struct http_auth_source source = {0};
+    EXPECT(vertex_auth_source(NULL, &source) == 0);
+    EXPECT(source.ops->prepare(source.state, 1, NULL, NULL) == 0);
+    char **headers = source.ops->headers(source.state, "sid", 1);
+    EXPECT(strstr(headers[0], "Authorization: Bearer lit-tok") != NULL);
+    string_array_free(headers);
+    source.ops->destroy(source.state);
+
+    /* With the explicit token configured, availability passes even without an ADC file. */
+    struct provider_availability availability = {0};
+    vertex_prepare_availability(provider_find("vertex"), &availability);
+    EXPECT(availability.available);
+    provider_availability_clear(&availability);
+    EXPECT(config_load(NULL) == 0);
+}
+
+int main(void)
+{
+    signal(SIGPIPE, SIG_IGN);
+    test_resolve_base_url_host_rules();
+    test_def_registered();
+    test_messages_body_variant();
+    test_stream_raw_predict();
+    test_auth_source_user_refresh();
+    test_auth_source_literal();
+    T_REPORT();
+}


### PR DESCRIPTION
Follow-up to https://github.com/OleksandrChekhovskyi/hax/pull/17: Another attempt to add support for Anthropic models served by Vertex AI together with supporting config, catalog, and auth plumbing.

